### PR TITLE
Fix IRI for imported term GAZ_00003744

### DIFF
--- a/imports/gaz_insdc_mapping.owl
+++ b/imports/gaz_insdc_mapping.owl
@@ -2343,7 +2343,7 @@
 
      <!-- http://purl.obolibrary.org/obo/GAZ_00003744  -->
 
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00003744 ">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00003744">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">INSDC:country:siam</oboInOwl:hasDbXref>
         <!-- rdfs:label xml:lang="en">Thailand</rdfs:label -->
     </rdf:Description>


### PR DESCRIPTION
There's an errant whitespace that is causes imports to fail when run through the OWL API.