### PR TITLE
DH vocab travel classes

### DIFF
--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -7986,7 +7986,7 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001118 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001118">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001121"/>
         <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province of interest.</obo:IAO_0000115>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
         <rdfs:label xml:lang="en">travel outside province</rdfs:label>
@@ -7997,7 +7997,7 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001119 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001121"/>
         <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given territory of interest.</obo:IAO_0000115>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
         <rdfs:label xml:lang="en">travel outside territory</rdfs:label>
@@ -8012,6 +8012,17 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
         <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside Canada.</obo:IAO_0000115>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
         <rdfs:label xml:lang="en">travel outside Canada</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province/territory of interest.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">travel outside province/territory</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -5754,42 +5754,6 @@ Clusters passing filter are represented by PF in analysis reports. Clusters pass
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
-        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province of interest.</obo:IAO_0000115>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
-        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">travel outside province</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001001 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001001">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
-        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given territory of interest.</obo:IAO_0000115>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
-        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">travel outside territory</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001002 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
-        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside Canada.</obo:IAO_0000115>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
-        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">travel outside Canada</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0000101 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000101">
@@ -21987,8 +21951,8 @@ Note that this file contains examples of cities, provinces, states, territories,
         <oboInOwl:hasSynonym xml:lang="en">black tiger shrimp</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/FOODON_03530153">
-        <oboInOwl:hasSynonym xml:lang="en">wild</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">gathered</oboInOwl:hasSynonym>
+        <oboInOwl:hasSynonym xml:lang="en">wild</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000098">
         <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
@@ -22207,8 +22171,8 @@ Note that this file contains examples of cities, provinces, states, territories,
         <obo:GENEPIO_0000006>cfu/mL</obo:GENEPIO_0000006>
     </rdf:Description>
     <rdf:Description rdf:about="http://semanticscience.org/resource/SIO_000546">
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
         <obo:IAO_0000117 xml:lang="en">Damion Dooley</obo:IAO_0000117>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000246">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/PATO_0000011</oboInOwl:hasDbXref>
@@ -22224,14 +22188,6 @@ Note that this file contains examples of cities, provinces, states, territories,
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001000"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001001"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001002"/>
-        </owl:members>
-    </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -7983,6 +7983,39 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province of interest.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">travel outside province</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given territory of interest.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">travel outside territory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside Canada.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">travel outside Canada</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001126 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001126">
@@ -21951,16 +21984,16 @@ Note that this file contains examples of cities, provinces, states, territories,
         <oboInOwl:hasSynonym xml:lang="en">black tiger shrimp</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/FOODON_03530153">
-        <oboInOwl:hasSynonym xml:lang="en">gathered</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">wild</oboInOwl:hasSynonym>
+        <oboInOwl:hasSynonym xml:lang="en">gathered</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000098">
         <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000116">
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
-        <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
         <obo:IAO_0000115 xml:lang="en">This is a catch-all category for Gazetteer items that have &quot;located in&quot; relations but not an imported GAZETTEER class parent in GenEpiO.</obo:IAO_0000115>
+        <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001605">
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -22171,8 +22204,8 @@ Note that this file contains examples of cities, provinces, states, territories,
         <obo:GENEPIO_0000006>cfu/mL</obo:GENEPIO_0000006>
     </rdf:Description>
     <rdf:Description rdf:about="http://semanticscience.org/resource/SIO_000546">
-        <obo:IAO_0000117 xml:lang="en">Damion Dooley</obo:IAO_0000117>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000117 xml:lang="en">Damion Dooley</obo:IAO_0000117>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000246">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/PATO_0000011</oboInOwl:hasDbXref>
@@ -22204,6 +22237,14 @@ Note that this file contains examples of cities, provinces, states, territories,
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001007"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001835"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001836"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001118"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001120"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -5754,6 +5754,42 @@ Clusters passing filter are represented by PF in analysis reports. Clusters pass
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province of interest.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">travel outside province</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given territory of interest.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">travel outside territory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_00001002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
+        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside Canada.</obo:IAO_0000115>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <obo:IAO_0000119>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">travel outside Canada</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0000101 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000101">
@@ -21951,8 +21987,8 @@ Note that this file contains examples of cities, provinces, states, territories,
         <oboInOwl:hasSynonym xml:lang="en">black tiger shrimp</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/FOODON_03530153">
-        <oboInOwl:hasSynonym xml:lang="en">gathered</oboInOwl:hasSynonym>
         <oboInOwl:hasSynonym xml:lang="en">wild</oboInOwl:hasSynonym>
+        <oboInOwl:hasSynonym xml:lang="en">gathered</oboInOwl:hasSynonym>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000098">
         <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
@@ -22171,8 +22207,8 @@ Note that this file contains examples of cities, provinces, states, territories,
         <obo:GENEPIO_0000006>cfu/mL</obo:GENEPIO_0000006>
     </rdf:Description>
     <rdf:Description rdf:about="http://semanticscience.org/resource/SIO_000546">
-        <obo:IAO_0000117 xml:lang="en">Damion Dooley</obo:IAO_0000117>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000117 xml:lang="en">Damion Dooley</obo:IAO_0000117>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000246">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/PATO_0000011</oboInOwl:hasDbXref>
@@ -22188,6 +22224,14 @@ Note that this file contains examples of cities, provinces, states, territories,
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001000"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001001"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_00001002"/>
+        </owl:members>
+    </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -7955,28 +7955,6 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001118 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001118">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001121"/>
-        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province of interest.</obo:IAO_0000115>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">travel outside province</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001119 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001121"/>
-        <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given territory of interest.</obo:IAO_0000115>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">travel outside territory</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001120 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
         <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside Canada.</obo:IAO_0000115>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
@@ -7985,9 +7963,9 @@ GENEPIO:0002181 # antimicrobial resistance phenotype - ECOFF</obo:GENEPIO_000176
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001121 -->
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001119 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001121">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001783"/>
         <obo:IAO_0000115 xml:lang="en">A travel destination which a given human has travelled to on a particular trip and is outside a given province/territory of interest.</obo:IAO_0000115>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
@@ -22216,14 +22194,6 @@ Note that this file contains examples of cities, provinces, states, territories,
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001007"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001835"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001836"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001118"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001119"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001120"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>


### PR DESCRIPTION
New Subclasses under `travel destination` (GENEPIO_0001783) to be used in the **DataHarmonizer** contextual data *Exposures* vocabulary.

- `travel outside Canada` (GENEPIO_0001120)
- `travel outside province/territory` (GENEPIO_0001121)
  - `travel outside province` (GENEPIO_0001118)
  - `travel outside territory` (GENEPIO_0001119)


All terms have have the following annotations: `label`, `definition`, and `term editor`.