### PR TITLE
CanCOGeN - database identifiers

### DIFF
--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21666,6 +21666,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001143 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001143">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>MN908947.3</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:22:41Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:GenBank accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21712,6 +21712,19 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001146 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001146">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>EPI_ISL_436489</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:33:13Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:GISAID accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21743,6 +21743,19 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001148 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001148">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>SHK123456</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T18:48:39Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:Switch ID example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21482,6 +21482,23 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001131 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001131">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001129"/>
+        <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001130"/>
+        <linkml:comments xml:lang="en">Guidance: Store the IRIDA sample name. The IRIDA sample name will be created by the individual entering data into the IRIDA platform. IRIDA samples may be linked to metadata and sequence data, or just metadata alone. It is recommended that the IRIDA sample name be the same as, or contain, the specimen collector sample ID for better traceability. It is also recommended that the IRIDA sample name mirror the GISAID accession. IRIDA sample names cannot contain slashes. Slashes should be replaced by underscores. See IRIDA documentation for more information regarding special characters (https://irida.corefacility.ca/documentation/user/user/samples/#adding-a-new-sample).</linkml:comments>
+        <linkml:created_on xml:lang="en">2021-04-27T03:24:03Z</linkml:created_on>
+        <linkml:description xml:lang="en">The identifier assigned to a sequenced isolate in IRIDA.</linkml:description>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:IRIDA sample name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21692,6 +21692,26 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001145 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001145">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001143"/>
+        <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001144"/>
+        <linkml:comments xml:lang="en">Guidance: Store the accession returned from a GenBank submission (viral genome assembly).</linkml:comments>
+        <linkml:created_on>2021-04-27T04:27:48Z</linkml:created_on>
+        <linkml:description xml:lang="en">The GenBank identifier assigned to the sequence in the INSDC archives.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.ncbi.nlm.nih.gov/genbank/,
+https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:GenBank accession</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21574,6 +21574,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001137 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001137">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>SAMN14180202</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:55:21Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:biosample accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21679,6 +21679,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001144 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001144">
+        <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
+        <linkml:local_name_value>http://purl.obolibrary.org/obo/OBI_0001614</linkml:local_name_value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:25:46Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:GenBank accession local name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21543,6 +21543,18 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001135 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001135">
+        <linkml:local_name_value>http://purl.obolibrary.org/obo/GENEPIO_0001836</linkml:local_name_value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:46:59Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:bioproject accession local name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21426,6 +21426,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001127 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001127">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>SR20-12345</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:04:06Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:NML related specimen primary ID example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21439,6 +21439,23 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001128 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001128">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001127"/>
+        <linkml:comments xml:lang="en">Guidance: Store the primary ID of the related specimen previously submitted thorough LaSER</linkml:comments>
+        <linkml:created_on>2021-04-27T03:10:30Z</linkml:created_on>
+        <linkml:data_collection_state xml:lang="en">Not Applicable; Missing; Not Collected; Not Provided; Restricted Access</linkml:data_collection_state>
+        <linkml:description xml:lang="en">The primary ID of the related specimen previously submitted thorough LaSER</linkml:description>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">CanCOGeN:NML related specimen primary ID</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21756,6 +21756,23 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001149 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001149">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001148"/>
+        <linkml:comments xml:lang="en">Guidance: Store the identifier supplied by Seitch Health for the sample.</linkml:comments>
+        <linkml:created_on>2021-04-28T18:51:40Z</linkml:created_on>
+        <linkml:description xml:lang="en">The identifier assigned to a sample by Switch Health.</linkml:description>
+        <linkml:see_also>https://www.switchhealth.ca/en/</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:Switch ID</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21473,7 +21473,7 @@ Note that this file contains examples of cities, provinces, states, territories,
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001130">
         <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
-        <linkml:local_name_value xml:lang="en">http://purl.obolibrary.org/obo/GENEPIO_0001829</linkml:local_name_value>
+        <linkml:local_name_value>http://purl.obolibrary.org/obo/GENEPIO_0001829</linkml:local_name_value>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
         <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:21:11Z</dc11:date>
@@ -21546,6 +21546,7 @@ Note that this file contains examples of cities, provinces, states, territories,
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001135 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001135">
+        <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
         <linkml:local_name_value>http://purl.obolibrary.org/obo/GENEPIO_0001836</linkml:local_name_value>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21417,7 +21417,7 @@ Note that this file contains examples of cities, provinces, states, territories,
         <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001124"/>
         <linkml:comments xml:lang="en">Guidance: Store the identifier for the specimen submitted through the NML LaSER system.</linkml:comments>
         <linkml:created_on>2021-04-27T02:56:23Z</linkml:created_on>
-        <linkml:description xml:lang="en">The primary ID of the specimen submitted thorough LaSER.</linkml:description>
+        <linkml:description xml:lang="en">The primary ID of the specimen submitted thorough the National Microbiology Laboratory (NML) LaSER.</linkml:description>
         <linkml:type_uri>xs:token</linkml:type_uri>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
@@ -21447,7 +21447,7 @@ Note that this file contains examples of cities, provinces, states, territories,
         <linkml:comments xml:lang="en">Guidance: Store the primary ID of the related specimen previously submitted thorough LaSER</linkml:comments>
         <linkml:created_on>2021-04-27T03:10:30Z</linkml:created_on>
         <linkml:data_collection_state xml:lang="en">Not Applicable; Missing; Not Collected; Not Provided; Restricted Access</linkml:data_collection_state>
-        <linkml:description xml:lang="en">The primary ID of the related specimen previously submitted thorough LaSER</linkml:description>
+        <linkml:description xml:lang="en">The primary ID of the related specimen previously submitted thorough the National Microbiology Laboratory (NML) LaSER.</linkml:description>
         <linkml:type_uri>xs:token</linkml:type_uri>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21410,6 +21410,22 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001125 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001125">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001124"/>
+        <linkml:comments xml:lang="en">Guidance: Store the identifier for the specimen submitted through the NML LaSER system.</linkml:comments>
+        <linkml:created_on>2021-04-27T02:56:23Z</linkml:created_on>
+        <linkml:description xml:lang="en">The primary ID of the specimen submitted thorough LaSER.</linkml:description>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">CanCOGeN:NML submitted specimen primary ID</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21403,7 +21403,7 @@ Note that this file contains examples of cities, provinces, states, territories,
         <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
         <linkml:value>SR20-12345</linkml:value>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
-        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
         <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:49:57Z</dc11:date>
         <rdfs:label xml:lang="en">CanCOGeN:NML submitted specimen primary ID example</rdfs:label>
     </owl:NamedIndividual>
@@ -21452,6 +21452,19 @@ Note that this file contains examples of cities, provinces, states, territories,
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
         <rdfs:label xml:lang="en">CanCOGeN:NML related specimen primary ID</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001129 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001129">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>prov_rona_99</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:14:01Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:IRIDA sample name example</rdfs:label>
     </owl:NamedIndividual>
     
 

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -22012,6 +22012,7 @@ Note that this file contains examples of cities, provinces, states, territories,
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0002236 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0002236">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
         <linkml:value>prov_rona_99</linkml:value>
         <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0002-8844-9165"/>
         <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-24T18:32:24Z</dc11:date>
@@ -22116,8 +22117,8 @@ Note that this file contains examples of cities, provinces, states, territories,
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000116">
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
-        <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
         <obo:IAO_0000115 xml:lang="en">This is a catch-all category for Gazetteer items that have &quot;located in&quot; relations but not an imported GAZETTEER class parent in GenEpiO.</obo:IAO_0000115>
+        <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001605">
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21489,7 +21489,7 @@ Note that this file contains examples of cities, provinces, states, territories,
         <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001129"/>
         <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001130"/>
         <linkml:comments xml:lang="en">Guidance: Store the IRIDA sample name. The IRIDA sample name will be created by the individual entering data into the IRIDA platform. IRIDA samples may be linked to metadata and sequence data, or just metadata alone. It is recommended that the IRIDA sample name be the same as, or contain, the specimen collector sample ID for better traceability. It is also recommended that the IRIDA sample name mirror the GISAID accession. IRIDA sample names cannot contain slashes. Slashes should be replaced by underscores. See IRIDA documentation for more information regarding special characters (https://irida.corefacility.ca/documentation/user/user/samples/#adding-a-new-sample).</linkml:comments>
-        <linkml:created_on xml:lang="en">2021-04-27T03:24:03Z</linkml:created_on>
+        <linkml:created_on>2021-04-27T03:24:03Z</linkml:created_on>
         <linkml:description xml:lang="en">The identifier assigned to a sequenced isolate in IRIDA.</linkml:description>
         <linkml:type_uri>xs:token</linkml:type_uri>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
@@ -21508,6 +21508,24 @@ Note that this file contains examples of cities, provinces, states, territories,
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
         <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:35:36Z</dc11:date>
         <rdfs:label xml:lang="en">CanCOGeN:umbrella bioproject accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001133 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001133">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001132"/>
+        <linkml:comments xml:lang="en">Guidance: Store the umbrella BioProject accession by selecting it from the picklist in the template. The umbrella BioProject accession will be identical for all CanCOGen submitters. Different provinces will have their own BioProjects, however these BioProjects will be linked under one umbrella BioProject.</linkml:comments>
+        <linkml:created_on>2021-04-27T03:38:14Z</linkml:created_on>
+        <linkml:description xml:lang="en">The INSDC accession number assigned to the umbrella BioProject for the Canadian SARS-CoV-2 sequencing effort.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.ncbi.nlm.nih.gov/books/NBK54015/</linkml:see_also>
+        <linkml:type_uri>select</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:umbrella bioproject accession</rdfs:label>
     </owl:NamedIndividual>
     
 

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21588,6 +21588,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001138 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001138">
+        <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
+        <linkml:local_name_value>http://purl.obolibrary.org/obo/GENEPIO_0001836</linkml:local_name_value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:03:29Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:biosample accession local name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21620,6 +21620,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001140 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001140">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:examples>SRR11177792</linkml:examples>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:09:40Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:SRA accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21555,6 +21555,25 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001136 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001136">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001134"/>
+        <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001135"/>
+        <linkml:comments xml:lang="en">Guidance: Store the BioProject accession number. BioProjects are an organizing tool that links together raw sequence data, assemblies, and their associated metadata. Each province will be assigned a different bioproject accession number by the National Microbiology Lab. A valid NCBI BioProject accession has prefix PRJN e.g., PRJNA12345, and is created once at the beginning of a new sequencing project.</linkml:comments>
+        <linkml:description xml:lang="en">The INSDC accession number of the BioProject(s) to which the BioSample belongs.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.ncbi.nlm.nih.gov/bioproject/</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:50:41Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:bioproject accession</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21499,6 +21499,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001132 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001132">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value xml:lang="en">PRJNA623807</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:35:36Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:umbrella bioproject accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21469,6 +21469,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001130 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001130">
+        <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
+        <linkml:local_name_value xml:lang="en">http://purl.obolibrary.org/obo/GENEPIO_0001829</linkml:local_name_value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:21:11Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:IRIDA sample name local name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21601,6 +21601,25 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001139 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001139">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001137"/>
+        <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001138"/>
+        <linkml:comments xml:lang="en">Guidance: Store the accession returned from the BioSample submission. NCBI BioSamples will have the prefix SAMN.</linkml:comments>
+        <linkml:created_on>2021-04-27T04:06:03Z</linkml:created_on>
+        <linkml:description xml:lang="en">The identifier assigned to a BioSample in INSDC archives.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.ncbi.nlm.nih.gov/biosample</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:biosample accession</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21530,6 +21530,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001134 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001134">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>PRJNA608651</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T03:44:13Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:bioproject accession example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21725,6 +21725,24 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001147 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001147">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001146"/>
+        <linkml:comments xml:lang="en">Guidance: Store the accession returned from the GISAID submission.</linkml:comments>
+        <linkml:created_on>2021-04-27T04:36:10Z</linkml:created_on>
+        <linkml:description xml:lang="en">The GISAID accession number assigned to the sequence.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.gisaid.org/help/publish-with-data-from-gisaid/</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <rdfs:label xml:lang="en">CanCOGeN:GISAID accession</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21646,6 +21646,26 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001142 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001142">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001122"/>
+        <linkml:examples rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001140"/>
+        <linkml:local_names rdf:resource="http://purl.obolibrary.org/obo/GENEPIO_0001141"/>
+        <linkml:comments xml:lang="en">Guidance: Store the accession assigned to the submitted &quot;run&quot;. NCBI-SRA accessions start with SRR.</linkml:comments>
+        <linkml:created_on>2021-04-27T04:19:10Z</linkml:created_on>
+        <linkml:description xml:lang="en">The Sequence Read Archive (SRA) identifier linking raw read data, methodological metadata and quality control metrics submitted to the INSDC.</linkml:description>
+        <linkml:pattern>UPPER</linkml:pattern>
+        <linkml:see_also>https://www.ncbi.nlm.nih.gov/sra</linkml:see_also>
+        <linkml:type_uri>xs:token</linkml:type_uri>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:19:10Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:SRA accession</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21751,7 +21751,7 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
         <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-28T18:48:39Z</dc11:date>
-        <rdfs:label xml:lang="en">CanCOGeN:Switch ID example</rdfs:label>
+        <rdfs:label xml:lang="en">CanCOGeN:Switch Health ID example</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -21768,7 +21768,7 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
         <linkml:type_uri>xs:token</linkml:type_uri>
         <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
-        <rdfs:label xml:lang="en">CanCOGeN:Switch ID</rdfs:label>
+        <rdfs:label xml:lang="en">CanCOGeN:Switch Health ID</rdfs:label>
     </owl:NamedIndividual>
     
 
@@ -22493,8 +22493,8 @@ https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/</linkml:see_also>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0000116">
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000428"/>
-        <obo:IAO_0000115 xml:lang="en">This is a catch-all category for Gazetteer items that have &quot;located in&quot; relations but not an imported GAZETTEER class parent in GenEpiO.</obo:IAO_0000115>
         <obo:IAO_0000117>Damion Dooley</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">This is a catch-all category for Gazetteer items that have &quot;located in&quot; relations but not an imported GAZETTEER class parent in GenEpiO.</obo:IAO_0000115>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001605">
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21397,6 +21397,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001124 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001124">
+        <rdf:type rdf:resource="https://w3id.org/linkml/Example"/>
+        <linkml:value>SR20-12345</linkml:value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117>https://orcid.org/0000-0002-9578-0788</obo:IAO_0000117>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-26T23:49:57Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:NML submitted specimen primary ID example</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">

--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -21633,6 +21633,19 @@ Note that this file contains examples of cities, provinces, states, territories,
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GENEPIO_0001141 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001141">
+        <rdf:type rdf:resource="https://w3id.org/linkml/LocalName"/>
+        <linkml:local_name_value>http://purl.obolibrary.org/obo/GENEPIO_0000147</linkml:local_name_value>
+        <obo:IAO_0000114 xml:lang="en">requires discussion</obo:IAO_0000114>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-9578-0788"/>
+        <dc11:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-04-27T04:13:07Z</dc11:date>
+        <rdfs:label xml:lang="en">CanCOGeN:SRA accession local name</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GENEPIO_0001367 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/GENEPIO_0001367">


### PR DESCRIPTION
Added the following fields to `draft CanCOGeN DataHarmonizer specification - database identifiers`, `Example`, or `LocalName`:
- `CanCOGeN:specimen collector sample ID example`
- `CanCOGeN:NML submitted specimen primary ID`
- `CanCOGeN:NML submitted specimen primary ID example`
- `CanCOGeN:NML related specimen primary ID`
- `CanCOGeN:NML related specimen primary ID example`
- `CanCOGeN:IRIDA sample name`
- `CanCOGeN:IRIDA sample name example`
- `CanCOGeN:IRIDA sample name local name`
- `CanCOGeN:umbrella bioproject accession`
- `CanCOGeN:umbrella bioproject accession example`
- `CanCOGeN:bioproject accession`
- `CanCOGeN:bioproject accession example`
- `CanCOGeN:bioproject accession local name`
- `CanCOGeN:biosample accession`
- `CanCOGeN:biosample accession example`
- `CanCOGeN:biosample accession local name`
- `CanCOGeN:SRA accession`
- `CanCOGeN:SRA accession example`
- `CanCOGeN:SRA accession local name`
- `CanCOGeN:GenBank accession`
- `CanCOGeN:GenBank accession example`
- `CanCOGeN:GenBank accession local name`
- `CanCOGeN:GISAID accession`
- `CanCOGeN:GISAID accession example`

Update (2021-04-28):

- `CanCOGeN:Switch ID`
- `CanCOGeN:Switch ID example`