### PR TITLE
type_uri and other corrections

### DIFF
--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -14001,7 +14001,7 @@ DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001123 "Not Appl
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001123 "The user-defined name for the sample."@en)
 DataPropertyAssertion(linkml:identifier obo:GENEPIO_0001123 "true"^^xsd:boolean)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001123 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001123 "xsd:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001123 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001124 (CanCOGeN:NML submitted specimen primary ID example)
 
@@ -14022,7 +14022,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001125 obo:GENEPIO_0001124)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001125 "Guidance: Store the identifier for the specimen submitted through the NML LaSER system."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001125 "2021-04-27T02:56:23Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001125 "The primary ID of the specimen submitted thorough the National Microbiology Laboratory (NML) LaSER."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001125 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001125 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001127 (CanCOGeN:NML related specimen primary ID example)
 
@@ -14044,7 +14044,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001128 "Guidance: Store the p
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001128 "2021-04-27T03:10:30Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001128 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001128 "The primary ID of the related specimen previously submitted thorough the National Microbiology Laboratory (NML) LaSER."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001128 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001128 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001129 (CanCOGeN:IRIDA sample name example)
 
@@ -14075,7 +14075,7 @@ ObjectPropertyAssertion(linkml:local_names obo:GENEPIO_0001131 obo:GENEPIO_00011
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001131 "Guidance: Store the IRIDA sample name. The IRIDA sample name will be created by the individual entering data into the IRIDA platform. IRIDA samples may be linked to metadata and sequence data, or just metadata alone. It is recommended that the IRIDA sample name be the same as, or contain, the specimen collector sample ID for better traceability. It is also recommended that the IRIDA sample name mirror the GISAID accession. IRIDA sample names cannot contain slashes. Slashes should be replaced by underscores. See IRIDA documentation for more information regarding special characters (https://irida.corefacility.ca/documentation/user/user/samples/#adding-a-new-sample)."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001131 "2021-04-27T03:24:03Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001131 "The identifier assigned to a sequenced isolate in IRIDA."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001131 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001131 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001132 (CanCOGeN:umbrella bioproject accession example)
 
@@ -14164,7 +14164,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001139 "2021-04-27T04:06:03
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001139 "The identifier assigned to a BioSample in INSDC archives."@en)
 DataPropertyAssertion(linkml:pattern obo:GENEPIO_0001139 "UPPER")
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001139 "https://www.ncbi.nlm.nih.gov/biosample"^^xsd:anyURI)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001139 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001139 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001140 (CanCOGeN:SRA accession example)
 
@@ -14173,6 +14173,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:GENEPIO_0001140 <https://orcid.org/0000-
 AnnotationAssertion(dc11:date obo:GENEPIO_0001140 "2021-04-27T04:09:40Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:GENEPIO_0001140 "CanCOGeN:SRA accession example")
 ClassAssertion(linkml:Example obo:GENEPIO_0001140)
+DataPropertyAssertion(linkml:value obo:GENEPIO_0001140 "SRR11177792")
 
 # Individual: obo:GENEPIO_0001141 (CanCOGeN:SRA accession local name)
 
@@ -14197,7 +14198,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001142 "2021-04-27T04:19:10
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001142 "The Sequence Read Archive (SRA) identifier linking raw read data, methodological metadata and quality control metrics submitted to the INSDC."@en)
 DataPropertyAssertion(linkml:pattern obo:GENEPIO_0001142 "UPPER")
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001142 "https://www.ncbi.nlm.nih.gov/sra"^^xsd:anyURI)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001142 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001142 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001143 (CanCOGeN:GenBank accession example)
 
@@ -14231,7 +14232,7 @@ DataPropertyAssertion(linkml:description obo:GENEPIO_0001145 "The GenBank identi
 DataPropertyAssertion(linkml:pattern obo:GENEPIO_0001145 "UPPER")
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001145 "https://www.ncbi.nlm.nih.gov/genbank/"^^xsd:anyURI)
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001145 "https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/"^^xsd:anyURI)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001145 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001145 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001146 (CanCOGeN:GISAID accession example)
 
@@ -14254,7 +14255,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001147 "2021-04-27T04:36:10
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001147 "The GISAID accession number assigned to the sequence."@en)
 DataPropertyAssertion(linkml:pattern obo:GENEPIO_0001147 "UPPER")
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001147 "https://www.gisaid.org/help/publish-with-data-from-gisaid/"^^xsd:anyURI)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001147 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001147 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001148 (CanCOGeN:third party lab sample ID example)
 
@@ -14276,7 +14277,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001149 "Guidance: Store the i
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001149 "2021-04-28T18:51:40Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001149 "The identifier assigned to a sample by a third party service provider."@en)
 DataPropertyAssertion(linkml:see_also obo:GENEPIO_0001149 "https://www.switchhealth.ca/en/"^^xsd:anyURI)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001149 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001149 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001153 (CanCOGeN:sample collected by)
 
@@ -14290,7 +14291,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001153 "2021-05-04T05:12:55
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001153 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001153 "The name of the agency that collected the original sample."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001153 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001153 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001153 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001155 (CanCOGeN:sample collector contact email example)
 
@@ -14310,7 +14311,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001156 obo:GENEPIO_0001155)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001156 "Guidance: The email address can represent a specific individual or lab e.g. johnnyblogs@lab.ca, or RespLab@lab.ca."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001156 "2021-05-04T05:19:56Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001156 "The email address of the contact responsible for follow-up regarding the sample."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001156 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001156 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001157 (CanCOGeN:sample collector contact address example)
 
@@ -14323,9 +14324,15 @@ DataPropertyAssertion(linkml:value obo:GENEPIO_0001157 "655 Lab St, Vancouver, B
 
 # Individual: obo:GENEPIO_0001158 (CanCOGeN:sample collector contact address)
 
-AnnotationAssertion(dc11:date obo:GENEPIO_0001158 "2021-05-04T05:25:17Z"^^xsd:dateTime)
+AnnotationAssertion(obo:IAO_0000114 obo:GENEPIO_0001158 "requires discussion"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:GENEPIO_0001158 <https://orcid.org/0000-0002-9578-0788>)
 AnnotationAssertion(rdfs:label obo:GENEPIO_0001158 "CanCOGeN:sample collector contact address")
 ClassAssertion(obo:GENEPIO_0001150 obo:GENEPIO_0001158)
+ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001158 obo:GENEPIO_0001157)
+DataPropertyAssertion(linkml:comments obo:GENEPIO_0001158 "Guidance: The mailing address should be in the format: Street number and name, City, Province/Territory, Postal Code, Country."@en)
+DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001158 "2021-05-04T05:25:17Z")
+DataPropertyAssertion(linkml:description obo:GENEPIO_0001158 "The mailing address of the agency submitting the sample."@en)
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001158 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001159 (CanCOGeN:sequence submitted by)
 
@@ -14369,7 +14376,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001165 obo:GENEPIO_0001161)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001165 "Guidance: The email address can represent a specific individual or lab e.g. johnnyblogs@lab.ca, or RespLab@lab.ca."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001165 "2021-05-04T05:33:30Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001165 "The email address of the contact responsible for follow-up regarding the sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001165 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001165 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001166 (CanCOGeN:sequence submitter contact address example)
 
@@ -14390,7 +14397,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001167 obo:GENEPIO_0001166)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001167 "Guidance: The mailing address should be in the format: Street number and name, City, Province/Territory, Postal Code, Country"@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001167 "2021-05-04T05:37:25Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001167 "The mailing address of the agency submitting the sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001167 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001167 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001173 (CanCOGeN:sample collection date example)
 
@@ -14413,7 +14420,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001174 "2021-05-05T05:27:36
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001174 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001174 "The date on which the sample was collected."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001174 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001174 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001174 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001176 (CanCOGeN:sample collection date precision example)
 
@@ -14435,7 +14442,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001177 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001177 "2021-05-05T19:51:36Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001177 "The precision to which the \"sample collection date\" was provided."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001177 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001177 "select"@en)
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001177 "select")
 
 # Individual: obo:GENEPIO_0001178 (CanCOGeN:sample received date example)
 
@@ -14457,7 +14464,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001179 "Guidance: ISO 8601 st
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001179 "2021-05-05T19:55:31Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001179 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001179 "The date on which the sample was received."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001179 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001179 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001180 (CanCOGeN:geo_loc_name (country) example)
 
@@ -14524,7 +14531,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001189 obo:GENEPIO_0001188)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001189 "Guidance: Provide the city name. Use this look-up service to identify the standardized term: https://www.ebi.ac.uk/ols/ontologies/gaz"@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001189 "2021-05-05T20:09:29Z"^^xsd:dateTime)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001189 "The city where the sample was collected."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001189 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001189 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001190 (CanCOGeN:organism example)
 
@@ -14570,7 +14577,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001195 "2021-05-05T20:19:08
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001195 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001195 "Identifier of the specific isolate."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001195 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001195 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001195 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001197 (CanCOGeN:purpose of sampling example)
 
@@ -14616,7 +14623,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001200 "2021-05-05T20:29:50
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001200 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001200 "The description of why the sample was collected, providing specific details."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001200 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001200 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001200 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001201 (CanCOGeN:third party lab service provider name example)
 
@@ -14637,7 +14644,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001202 obo:GENEPIO_0001201)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001202 "Guidance: Store the sample identifier supplied by the third party services provider."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001202 "2021-05-05T21:02:51Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001202 "The name of the third party company or laboratory that provided services."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001202 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001202 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001203 (CanCOGeN:NML submitted specimen type example)
 
@@ -14863,7 +14870,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001243 obo:GENEPIO_0001242)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001243 "Guidance: Free text."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001243 "2021-06-05T05:12:09Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001243 "The name and version of a particular protocol used for sampling."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001243 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001243 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001252 (CanCOGeN:specimen processing example)
 
@@ -14934,6 +14941,7 @@ ClassAssertion(obo:GENEPIO_0001150 obo:GENEPIO_0001261)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001261 "Guidance: Provide number of known passages. If not passaged, put \"not applicable\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001261 "2021-06-05T16:06:51Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001261 "Number of passages."@en)
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001261 ""^^xsd:nonNegativeInteger)
 
 # Individual: obo:GENEPIO_0001263 (CanCOGeN:passage method example)
 
@@ -14955,7 +14963,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001264 "2021-06-05T16:16:51
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001264 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001264 "Description of how organism was passaged."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001264 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001264 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001264 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001265 (CanCOGeN:biomaterial extracted example)
 
@@ -15346,6 +15354,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:GENEPIO_0001326 <https://orcid.org/0000-
 AnnotationAssertion(dc11:date obo:GENEPIO_0001326 "2021-06-05T23:11:15Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:GENEPIO_0001326 "CanCOGeN:purpose of sequencing example")
 ClassAssertion(linkml:Example obo:GENEPIO_0001326)
+DataPropertyAssertion(linkml:value obo:GENEPIO_0001326 "Diagnostic testing")
 
 # Individual: obo:GENEPIO_0001327 (CanCOGeN:purpose of sequencing details example)
 
@@ -15915,7 +15924,7 @@ DataPropertyAssertion(linkml:description obo:GENEPIO_0001392 "Age of host at the
 DataPropertyAssertion(linkml:maximum_value obo:GENEPIO_0001392 "130"^^xsd:integer)
 DataPropertyAssertion(linkml:minimum_value obo:GENEPIO_0001392 "0"^^xsd:integer)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001392 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001392 "xs:decimal")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001392 ""^^xsd:decimal)
 
 # Individual: obo:GENEPIO_0001393 (CanCOGeN:host age unit)
 
@@ -15996,7 +16005,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001398 obo:GENEPIO_0001296)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001398 "Guidance: Provide the host identifier. Should be a unique, user-defined identifier."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001398 "2021-06-06T01:51:47Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001398 "A unique identifier by which each host can be referred to e.g. #131"@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001398 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001398 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001399 (CanCOGeN:symptom onset date)
 
@@ -16009,7 +16018,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001399 "Guidance: ISO 8601 st
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001399 "2021-06-06T01:55:32Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001399 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001399 "The date on which the symptoms began or were first noted."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001399 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001399 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001400 (CanCOGeN:signs and symptoms)
 
@@ -16025,11 +16034,11 @@ DataPropertyAssertion(linkml:description obo:GENEPIO_0001400 "A perceived change
 DataPropertyAssertion(linkml:multivalued obo:GENEPIO_0001400 "true"^^xsd:boolean)
 DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001400 "multiple")
 
-# Individual: obo:GENEPIO_0001401 (CanCOGeN:pre-existing conditions and risk factorsCanCOGeN:pre-existing conditions and risk factors)
+# Individual: obo:GENEPIO_0001401 (CanCOGeN:pre-existing conditions and risk factors)
 
 AnnotationAssertion(obo:IAO_0000114 obo:GENEPIO_0001401 "requires discussion"@en)
 AnnotationAssertion(obo:IAO_0000117 obo:GENEPIO_0001401 <https://orcid.org/0000-0002-9578-0788>)
-AnnotationAssertion(rdfs:label obo:GENEPIO_0001401 "CanCOGeN:pre-existing conditions and risk factorsCanCOGeN:pre-existing conditions and risk factors")
+AnnotationAssertion(rdfs:label obo:GENEPIO_0001401 "CanCOGeN:pre-existing conditions and risk factors")
 ClassAssertion(obo:GENEPIO_0001268 obo:GENEPIO_0001401)
 ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001401 obo:GENEPIO_0001300)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001401 "Guidance: Select all of the pre-existing conditions and risk factors experienced by the host from the pick list. If the desired term is missing, contact the curation team."@en)
@@ -16078,7 +16087,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001405 obo:GENEPIO_0001304)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001405 "Guidance: Free text. Provide the name of the vaccine."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001405 "2021-06-06T02:29:12Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001405 "The name of the vaccine."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001405 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001405 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001406 (CanCOGeN:number of vaccine doses received)
 
@@ -16090,7 +16099,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001406 obo:GENEPIO_0001305)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001406 "Guidance: Record how many doses of the vaccine the host has received."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001406 "2021-06-06T02:31:41Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001406 "The number of doses of the vaccine recived by the host."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001406 "https://orcid.org/0000-0002-9578-0788")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001406 ""^^xsd:nonNegativeInteger)
 
 # Individual: obo:GENEPIO_0001407 (CanCOGeN:first dose vaccination date)
 
@@ -16102,7 +16111,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001407 obo:GENEPIO_0001306)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001407 "Guidance: Provide the vaccination date in ISO 8601 standard format \"YYYY-MM-DD\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001407 "2021-06-06T02:37:31Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001407 "The date the host was first vaccinated."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001407 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001407 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001408 (CanCOGeN:last dose vaccination date)
 
@@ -16114,7 +16123,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001408 obo:GENEPIO_0001307)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001408 "Guidance: Provide the date that the last dose of the vaccine was administered. Provide the last dose vaccination date in ISO 8601 standard format \"YYYY-MM-DD\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001408 "2021-06-06T02:40:02Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001408 "The date the host received their last dose of vaccine."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001408 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001408 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001410 (CanCOGeN:location of exposure geo_loc name (country))
 
@@ -16138,7 +16147,7 @@ ClassAssertion(obo:GENEPIO_0001409 obo:GENEPIO_0001411)
 ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001411 obo:GENEPIO_0001309)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001411 "Guidance: Provide the name of the city that the host travelled to. Use this look-up service to identify the standardized term: https://www.ebi.ac.uk/ols/ontologies/gaz"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001411 "The name of the city that was the destination of most recent travel."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001411 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001411 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001412 (CanCOGeN:destination of most recent travel (state/province/territory))
 
@@ -16150,7 +16159,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001412 obo:GENEPIO_0001310)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001412 "Guidance: Provide the name of the state/province/territory that the host travelled to. Use this look-up service to identify the standardized term: https://www.ebi.ac.uk/ols/ontologies/gaz"@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001412 "2021-06-06T02:53:39Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001412 "The name of the province that was the destination of most recent travel."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001412 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001412 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001413 (CanCOGeN:destination of most recent travel (country))
 
@@ -16176,7 +16185,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001414 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001414 "2021-06-06T02:59:30Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001414 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001414 "The date of a person's most recent departure from their primary residence (at that time) on a journey to one or more other locations."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001414 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001414 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001415 (CanCOGeN:most recent travel return date)
 
@@ -16189,7 +16198,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001415 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001415 "2021-06-06T03:02:03Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001415 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001415 "The date of a person's most recent return to some residence from a journey originating at that residence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001415 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001415 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001416 (CanCOGeN:travel history)
 
@@ -16201,7 +16210,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001416 obo:GENEPIO_0001314)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001416 "Guidance: Specify the countries (and more granular locations if known, separated by a comma) travelled in the last six months; can include multiple travels. Separate multiple travel events with a semi-colon. List most recent travel first."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001416 "2021-06-06T03:05:00Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001416 "Travel history in last six months."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001416 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001416 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001417 (CanCOGeN:exposure event)
 
@@ -16265,7 +16274,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001431 obo:GENEPIO_0001319)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001431 "Guidance: Free text description of the exposure."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001431 "2021-06-06T03:17:19Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001431 "Additional host exposure information."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001431 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001431 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001435 (CanCOGeN:prior SARS-CoV-2 infection)
 
@@ -16290,7 +16299,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001436 obo:GENEPIO_0001321)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001436 "Guidance: Provide the isolate name of the most recent prior infection. Structure the \"isolate\" name to be ICTV/INSDC compliant in the following format: \"SARS-CoV-2/host/country/sampleID/date\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001436 "2021-06-06T03:43:38Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001436 "The identifier of the isolate found in the prior SARS-CoV-2 infection."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001436 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001436 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001437 (CanCOGeN:prior SARS-CoV-2 infection date)
 
@@ -16302,7 +16311,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001437 obo:GENEPIO_0001322)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001437 "Guidance: Provide the date that the most recent prior infection was diagnosed. Provide the prior SARS-CoV-2 infection date in ISO 8601 standard format \"YYYY-MM-DD\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001437 "2021-06-06T03:47:22Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001437 "The date of diagnosis of the prior SARS-CoV-2 infection."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001437 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001437 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001438 (CanCOGeN:prior SARS-CoV-2 antiviral treatment)
 
@@ -16327,7 +16336,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001439 obo:GENEPIO_0001324)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001439 "Guidance: Provide the name of the antiviral treatment agent administered during the most recent prior infection. If no treatment was administered, put \"No treatment\". If multiple antiviral agents were administered, list them all separated by commas."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001439 "2021-06-06T03:52:27Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001439 "The name of the antiviral treatment agent administered during the prior SARS-CoV-2 infection."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001439 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001439 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001440 (CanCOGeN:prior SARS-CoV-2 antiviral treatment date)
 
@@ -16339,7 +16348,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001440 obo:GENEPIO_0001325)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001440 "Guidance: Provide the date that the antiviral treatment agent was first administered during the most recenrt prior infection. Provide the prior SARS-CoV-2 treatment date in ISO 8601 standard format \"YYYY-MM-DD\"."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001440 "2021-06-06T03:55:02Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001440 "The date treatment was first administered during the prior SARS-CoV-2 infection."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001440 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001440 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001445 (CanCOGeN:purpose of sequencing)
 
@@ -16368,7 +16377,7 @@ DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001446 "2021-06-06T04:02:15
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001446 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001446 "The description of why the sample was sequenced providing specific details."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001446 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001446 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001446 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001447 (CanCOGeN:sequencing date)
 
@@ -16381,7 +16390,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001447 "Guidance: ISO 8601 st
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001447 "2021-06-06T04:05:23Z")
 DataPropertyAssertion(linkml:data_collection_state obo:GENEPIO_0001447 "Not Applicable; Missing; Not Collected; Not Provided; Restricted Access"@en)
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001447 "The date the sample was sequenced."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001447 "xs:date")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001447 ""^^xsd:date)
 
 # Individual: obo:GENEPIO_0001448 (CanCOGeN:library ID)
 
@@ -16394,7 +16403,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001448 "Guidance: The library
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001448 "2021-06-06T04:08:07Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001448 "The user-specified identifier for the library prepared for sequencing."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001448 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001448 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001448 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001449 (CanCOGeN:amplicon size)
 
@@ -16406,7 +16415,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001449 obo:GENEPIO_0001330)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001449 "Guidance: Provide the amplicon size, including the units."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001449 "2021-06-06T04:10:22Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001449 "The length of the amplicon generated by PCR amplification."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001449 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001449 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001450 (CanCOGeN:library preparation kit)
 
@@ -16418,7 +16427,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001450 obo:GENEPIO_0001331)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001450 "Guidance: Provide the name of the library preparation kit used."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001450 "2021-06-06T04:12:44Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001450 "The name of the DNA library preparation kit used to generate the library being sequenced."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001450 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001450 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001451 (CanCOGeN:flow cell barcode)
 
@@ -16430,7 +16439,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001451 obo:GENEPIO_0001332)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001451 "Guidance: Provide the barcode of the flow cell used for sequencing the sample."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001451 "2021-06-06T04:15:34Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001451 "The barcode of the flow cell used for sequencing."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001451 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001451 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001452 (CanCOGeN:sequencing instrument)
 
@@ -16458,7 +16467,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001453 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001453 "2021-06-06T04:21:01Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001453 "The name and version number of the sequencing protocol used."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001453 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001453 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001453 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001454 (CanCOGeN:sequencing protocol)
 
@@ -16470,7 +16479,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001454 obo:GENEPIO_0001335)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001454 "Guidance: Provide a free text description of the methods and materials used to generate the sequence. Suggested text, fill in information where indicated.: \"Viral sequencing was performed following a tiling amplicon strategy using the <fill in> primer scheme. Sequencing was performed using a <fill in> sequencing instrument. Libraries were prepared using <fill in> library kit.\""@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001454 "2021-06-06T04:23:45Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001454 "The protocol used to generate the sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001454 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001454 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001455 (CanCOGeN:sequencing kit number)
 
@@ -16482,7 +16491,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001455 obo:GENEPIO_0001336)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001455 "Guidance: Alphanumeric value."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001455 "2021-06-06T04:26:08Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001455 "The manufacturer's kit number."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001455 "xs:token"@en)
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001455 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001456 (CanCOGeN:amplicon pcr primer scheme)
 
@@ -16494,7 +16503,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001456 obo:GENEPIO_0001337)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001456 "Guidance: Provide the name and version of the primer scheme used to generate the amplicons for sequencing."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001456 "2021-06-06T04:28:35Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001456 "The specifications of the primers (primer sequences, binding positions, fragment size generated etc) used to generate the amplicons to be sequenced."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001456 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001456 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001458 (CanCOGeN:raw sequence data processing method)
 
@@ -16507,7 +16516,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001458 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001458 "2021-06-06T04:34:17Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001458 "The names of the software and version number used for raw data processing such as removing barcodes, adapter trimming, filtering etc."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001458 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001458 "xs:token"@en)
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001458 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001459 (CanCOGeN:dehosting method)
 
@@ -16519,7 +16528,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001459 obo:GENEPIO_0001341)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001459 "Guidance: Provide the name and version number of the software used to remove host reads."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001459 "2021-06-06T04:41:47Z2021-06-06T04:41:47Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001459 "The method used to remove host reads from the pathogen sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001459 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001459 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001460 (CanCOGeN:consensus sequence name)
 
@@ -16531,7 +16540,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001460 obo:GENEPIO_0001343)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001460 "Guidance: Provide the name and version number of the consensus sequence."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001460 "2021-06-06T04:44:41Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001460 "The name of the consensus sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001460 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001460 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001461 (CanCOGeN:consensus sequence filename)
 
@@ -16543,7 +16552,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001461 obo:GENEPIO_0001344)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001461 "Guidance: Provide the name and version number of the consensus sequence FASTA file."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001461 "2021-06-06T04:47:05Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001461 "The name of the consensus sequence file."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001461 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001461 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001462 (CanCOGeN:consensus sequence filepath)
 
@@ -16555,7 +16564,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001462 obo:GENEPIO_0001345)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001462 "Guidance: Provide the filepath of the consensus sequence FASTA file."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001462 "2021-06-06T04:49:26Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001462 "The filepath of the consesnsus sequence file."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001462 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001462 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001463 (CanCOGeN:consensus sequence software name)
 
@@ -16568,7 +16577,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001463 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001463 "2021-06-06T04:53:51Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001463 "The name of software used to generate the consensus sequence.The name of software used to generate the consensus sequence."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001463 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001463 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001463 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001469 (CanCOGeN:consensus sequence software version)
 
@@ -16581,7 +16590,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001469 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001469 "2021-06-06T04:56:20Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001469 "The version of the software used to generate the consensus sequence."@en)
 DataPropertyAssertion(linkml:required obo:GENEPIO_0001469 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001469 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001469 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001472 (CanCOGeN:breadth of coverage value)
 
@@ -16593,7 +16602,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001472 obo:GENEPIO_0001348)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001472 "Guidance: Provide value as a percent."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001472 "2021-06-06T04:58:59Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001472 "The percentage of the reference genome covered by the sequenced data, to a prescribed depth."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001472 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001472 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001474 (CanCOGeN:depth of coverage value)
 
@@ -16605,7 +16614,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001474 obo:GENEPIO_0001349)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001474 "Guidance: Provide value as a fold of coverage."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001474 "2021-06-06T05:01:30Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001474 "The average number of reads representing a given nucleotide in the reconstructed sequence."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001474 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001474 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001475 (CanCOGeN:depth of coverage threshold)
 
@@ -16617,7 +16626,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001475 obo:GENEPIO_0001350)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001475 "Guidance: Provide the threshold fold coverage."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001475 "2021-06-06T05:03:32Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001475 "The threshold used as a cut-off for the depth of coverage."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001475 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001475 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001476 (CanCOGeN:r1 fastq filename)
 
@@ -16630,7 +16639,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001476 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001476 "2021-06-06T05:05:51Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001476 "The user-specified filename of the r1 FASTQ file."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001476 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001476 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001476 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001477 (CanCOGeN:r2 fastq filename)
 
@@ -16643,7 +16652,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001477 "Guidance: Provide the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001477 "2021-06-06T05:09:13Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001477 "The user-specified filename of the r2 FASTQ file."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001477 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001477 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001477 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001478 (CanCOGeN:r1 fastq filepath)
 
@@ -16655,7 +16664,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001478 obo:GENEPIO_0001353)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001478 "Guidance: Provide the filepath for the r1 FASTQ file. This information aids in data management."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001478 "2021-06-06T05:11:46Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001478 "The location of the r1 FASTQ file within a user's file system."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001478 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001478 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001479 (CanCOGeN:r2 fastq filepath)
 
@@ -16667,7 +16676,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001479 obo:GENEPIO_0001354)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001479 "Guidance: Provide the filepath for the r2 FASTQ file. This information aids in data management."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001479 "2021-06-06T15:02:08Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001479 "The location of the r2 FASTQ file within a user's file system."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001479 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001479 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001480 (CanCOGeN:fast5 filename)
 
@@ -16679,7 +16688,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001480 obo:GENEPIO_0001355)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001480 "Guidance: Provide the FAST5 filename."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001480 "2021-06-06T15:05:06Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001480 "The user-specified filename of the FAST5 file."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001480 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001480 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001481 (CanCOGeN:fast5 filepath)
 
@@ -16691,7 +16700,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001481 obo:GENEPIO_0001357)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001481 "Guidance: Provide the filepath for the FAST5 file. This information aids in data management."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001481 "2021-06-06T15:07:22Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001481 "The location of the FAST5 file within a user's file system."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001481 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001481 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001482 (CanCOGeN:number of base pairs sequenced)
 
@@ -16703,7 +16712,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001482 obo:GENEPIO_0001358)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001482 "Guidance: Provide a numerical value (no need to include units)."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001482 "2021-06-06T15:10:14Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001482 "The number of total base pairs generated by the sequencing process."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001482 "xs:nonNegativeInteger")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001482 ""^^xsd:nonNegativeInteger)
 
 # Individual: obo:GENEPIO_0001483 (CanCOGeN:consensus genome length)
 
@@ -16715,7 +16724,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001483 obo:GENEPIO_0001359)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001483 "Guidance: Provide a numerical value (no need to include units)."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001483 "2021-06-06T15:13:54Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001483 "Size of the reconstructed genome described as the number of base pairs."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001483 "xs:nonNegativeInteger")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001483 ""^^xsd:nonNegativeInteger)
 
 # Individual: obo:GENEPIO_0001484 (CanCOGeN:Ns per 100 kbp)
 
@@ -16728,7 +16737,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001484 "Guidance: Provide a n
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001484 "2021-06-06T15:18:08Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001484 "The number of N symbols present in the consensus fasta sequence, per 100kbp of sequence."@en)
 DataPropertyAssertion(linkml:minimum_value obo:GENEPIO_0001484 "0"^^xsd:integer)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001484 "xs:decimal")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001484 ""^^xsd:decimal)
 
 # Individual: obo:GENEPIO_0001485 (CanCOGeN:reference genome accession)
 
@@ -16740,7 +16749,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001485 obo:GENEPIO_0001361)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001485 "Guidance: Provide the accession number of the reference genome."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001485 "2021-06-06T15:20:52Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001485 "A persistent, unique identifier of a genome database entry."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001485 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001485 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001489 (CanCOGeN:bioinformatics protocol)
 
@@ -16752,7 +16761,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001489 obo:GENEPIO_0001362)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001489 "Guidance: Further details regarding the methods used to process raw data, and/or generate assemblies, and/or generate consensus sequences can be provided in an SOP or protocol. Provide the name and version number of the protocol."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001489 "2021-06-06T15:23:18Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001489 "The name and version number of the bioinformatics protocol used."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001489 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001489 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001500 (CanCOGeN:lineage/clade name)
 
@@ -16764,7 +16773,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001500 obo:GENEPIO_0001363)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001500 "Guidance: Provide the Pangolin or Nextstrain lineage/clade name."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001500 "2021-06-06T15:32:22Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001500 "The name of the lineage or clade."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001500 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001500 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001501 (CanCOGeN:lineage/clade analysis software name)
 
@@ -16776,7 +16785,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001501 obo:GENEPIO_0001364)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001501 "Guidance: Provide the name of the software used to determine the lineage/clade."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001501 "2021-06-06T15:35:38Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001501 "The name of the software used to determine the lineage/clade."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001501 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001501 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001502 (CanCOGeN:lineage/clade analysis software version)
 
@@ -16788,7 +16797,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001502 obo:GENEPIO_0001365)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001502 "Guidance: Provide the version of the software used ot determine the lineage/clade."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001502 "2021-06-06T15:38:00Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001502 "The version of the software used to determine the lineage/clade."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001502 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001502 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001503 (CanCOGeN:variant designation)
 
@@ -16826,7 +16835,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001505 obo:GENEPIO_0001374)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001505 "Guidance: Provide the assay and list the set of lineage-defining mutations used to make the variant determination. If there are mutations of interest/concern observed in addition to lineage-defining mutations, describe those here."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001505 "2021-06-06T15:47:56Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001505 "Details about the evidence used to make the variant determination."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001505 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001505 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001507 (CanCOGeN:gene name 1)
 
@@ -16851,7 +16860,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001508 obo:GENEPIO_0001376)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001508 "Guidance: The name and version number of the protocol used for carrying out a diagnostic PCR test. This information can be compared to sequence data for evaluation of performance and quality control."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001508 "2021-06-06T15:55:20Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001508 "The name and version number of the protocol used for diagnostic marker amplification."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001508 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001508 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001509 (CanCOGeN:diagnostic pcr Ct value 1)
 
@@ -16888,7 +16897,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001511 obo:GENEPIO_0001379)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001511 "Guidance: The name and version number of the protocol used for carrying out a second diagnostic PCR test. This information can be compared to sequence data for evaluation of performance and quality control."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001511 "2021-06-06T16:23:57Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001511 "The name and version number of the protocol used for diagnostic marker amplification."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001511 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001511 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001512 (CanCOGeN:diagnostic pcr Ct value 2)
 
@@ -16900,7 +16909,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001512 obo:GENEPIO_0001380)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001512 "Guidance: Provide the CT value of the sample from the second diagnostic RT-PCR test."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001512 "2021-06-06T16:26:16Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001512 "The Ct value result from a diagnostic SARS-CoV-2 RT-PCR test."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001512 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001512 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001513 (CanCOGeN:gene name 3)
 
@@ -16925,7 +16934,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001514 obo:GENEPIO_0001382)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001514 "Guidance: The name and version number of the protocol used for carrying out a second diagnostic PCR test. This information can be compared to sequence data for evaluation of performance and quality control."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001514 "2021-06-06T16:30:58Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001514 "The name and version number of the protocol used for diagnostic marker amplification."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001514 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001514 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001515 (CanCOGeN:diagnostic pcr Ct value 3)
 
@@ -16937,7 +16946,7 @@ ObjectPropertyAssertion(linkml:examples obo:GENEPIO_0001515 obo:GENEPIO_0001383)
 DataPropertyAssertion(linkml:comments obo:GENEPIO_0001515 "Guidance: Provide the CT value of the sample from the second diagnostic RT-PCR test."@en)
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001515 "2021-06-06T16:33:11Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001515 "The Ct value result from a diagnostic SARS-CoV-2 RT-PCR test."@en)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001515 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001515 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001517 (CanCOGeN:authors)
 
@@ -16950,7 +16959,7 @@ DataPropertyAssertion(linkml:comments obo:GENEPIO_0001517 "Guidance: Include the
 DataPropertyAssertion(linkml:created_on obo:GENEPIO_0001517 "2021-06-06T16:37:30Z")
 DataPropertyAssertion(linkml:description obo:GENEPIO_0001517 "Names of individuals contributing to the processes of sample collection, sequence generation, analysis, and data submission."@en)
 DataPropertyAssertion(linkml:recommended obo:GENEPIO_0001517 "true"^^xsd:boolean)
-DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001517 "xs:token")
+DataPropertyAssertion(linkml:type_uri obo:GENEPIO_0001517 ""^^xsd:token)
 
 # Individual: obo:GENEPIO_0001518 (CanCOGeN:DataHarmonizer provenance)
 


### PR DESCRIPTION
Converted **type_uri** values:
- `xs:token` -> `xsd:token`
- `xs:nonNegativeInteger` -> `xsd:nonNegativeInteger`
- `xs:decimal` -> `xsd:decimal`
   - **Note:** `type_uri` does not show `xsd:decimal` in the Protege UI, but when you select to edit it `xsd:decimal` is present.
	   - Applicable Terms: `CanCOGeN:host age` and `CanCOGeN:Ns per 100 kbp`.
- `xs:date` -> `xsd:date`

Other **minor corrections** such as removed inappropriate @en tags and filling in missing example values.