### PR TITLE
canada_covid19 import owl

### DIFF
--- a/src/ontology/genepio-edit.owl
+++ b/src/ontology/genepio-edit.owl
@@ -36,6 +36,7 @@ Import(<http://purl.obolibrary.org/obo/genepio/imports/obi_import.owl>)
 Import(<http://purl.obolibrary.org/obo/genepio/imports/ontology-metadata.owl>)
 Import(<http://purl.obolibrary.org/obo/genepio/imports/ro_import.owl>)
 Import(<http://purl.obolibrary.org/obo/genepio/imports/uberon_import.owl>)
+Import(<http://purl.obolibrary.org/obo/vo/external/canada_covid19.owl>)
 Annotation(dc:description "The Genomic Epidemiology Ontology aims to provide a comprehensive controlled vocabulary for infectious disease surveillance and outbreak investigations. It is an application ontology that draws on many other ontologies including anatomy, taxonomy, disease, symptoms, environment and food types for foodborn pathogen metadata."@en)
 Annotation(dc:license <http://creativecommons.org/licenses/by/3.0/>)
 Annotation(dc:title "Genomic Epidemiology Ontology"@en)
@@ -2439,7 +2440,7 @@ SubClassOf(obo:APOLLO_SV_00000021 obo:STATO_0000047)
 
 SubClassOf(obo:APOLLO_SV_00000022 obo:STATO_0000047)
 
-# Class: obo:APOLLO_SV_00000031 (simulated population)
+# Class: obo:APOLLO_SV_00000031 (simulation of population)
 
 SubClassOf(obo:APOLLO_SV_00000031 obo:IAO_0000027)
 

--- a/src/ontology/imports/canada_covid19.owl
+++ b/src/ontology/imports/canada_covid19.owl
@@ -1,0 +1,1633 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/vo/external/canada_covid19.owl#"
+     xml:base="http://purl.obolibrary.org/obo/vo/external/canada_covid19.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:obo="http://purl.obolibrary.org/obo/">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/vo/external/canada_covid19.owl"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+        <rdfs:label>label</rdfs:label>
+        <rdfs:label xml:lang="en">label</rdfs:label>
+        <obo:IAO_0000111>label</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">label</obo:IAO_0000111>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <rdfs:label>editor preferred term</rdfs:label>
+        <rdfs:label>editor preferred term~editor preferred label</rdfs:label>
+        <rdfs:label>editor preferred label</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred label</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+        <obo:IAO_0000111>editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term~editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred term</obo:IAO_0000111>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0000195 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0000195">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CACO-2 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CACO-2 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0000836 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0000836">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MDBK cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MDBK cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0001444 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0001444">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vero cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vero cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0001865 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0001865">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PK-15 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PK-15 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0001950 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0001950">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HuH-7 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HuH-7 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0002035 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0002035">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">U-251MG cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">U-251MG cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0002181 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0002181">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HEK-293T cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HEK-293T cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0002750 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0002750">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calu-3 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calu-3 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0002909 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0002909">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RK-13 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RK-13 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0002924 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0002924">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NHBE cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NHBE cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BTO_0004755 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BTO_0004755">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VERO C1008 cell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VERO C1008 cell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/bto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000033">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to abattoir</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to abattoir</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000034 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000034">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to farm</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to farm</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000035 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000035">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to hospital</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to hospital</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000036 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000036">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to laboratory</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to laboratory</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000037">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to office</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to office</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000040 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000040">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to restaurant</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to restaurant</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_1000041 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_1000041">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to retail shop</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to retail shop</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_3000005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_3000005">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to humans</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to humans</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_5000008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_5000008">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to petting zoo</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to petting zoo</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_5000009 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_5000009">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to campground</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to campground</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_6000030 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_6000030">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to hunting</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to hunting</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ecto.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00003896 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00003896">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">currency note</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">currency note</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000404 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000404">
+        <rdfs:label>manufactured plastic</rdfs:label>
+        <obo:IAO_0000111>manufactured plastic</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000422 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000422">
+        <rdfs:label>bathroom</rdfs:label>
+        <obo:IAO_0000111>bathroom</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000481 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000481">
+        <rdfs:label>silica-based glass</rdfs:label>
+        <obo:IAO_0000111>silica-based glass</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000536 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000536">
+        <rdfs:label>factory</rdfs:label>
+        <obo:IAO_0000111>factory</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001481 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001481">
+        <rdfs:label xml:lang="en">public prision</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">public prision</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_02000058 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_02000058">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cloth</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cloth</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000206 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000206">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glossitis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glossitis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000223">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of taste sensation</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of taste sensation</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000224 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000224">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypogeusia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypogeusia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000421">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epistaxis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epistaxis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000458 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000458">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anosmia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anosmia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000509 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000509">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Conjunctivitis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Conjunctivitis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000737 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000737">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Irritability</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Irritability</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000822 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000822">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypertension</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypertension</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000961 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000961">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyanosis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyanosis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0000988 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0000988">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Skin rash</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Skin rash</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001063 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001063">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acrocyanosis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acrocyanosis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001250 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001250">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seizure</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seizure</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001259 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001259">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coma</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coma</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001289 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001289">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Confusion</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Confusion</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001297">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stroke</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stroke</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001324 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001324">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muscle weakness</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muscle weakness</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001638 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001638">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cardiomyopathy</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cardiomyopathy</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0001742 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0001742">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nasal congestion</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nasal congestion</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002090 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002090">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumonia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumonia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002094 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002094">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dyspnea</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dyspnea</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002105">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hemoptysis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hemoptysis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002371 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002371">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Loss of speech</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Loss of speech</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002383 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002383">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002615 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002615">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypotension</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypotension</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002789 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002789">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachypnea</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachypnea</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0002829 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0002829">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arthralgia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arthralgia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0004408 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0004408">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the sense of smell</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of the sense of smell</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0004409 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0004409">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hyposmia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hyposmia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0011446 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0011446">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of higher mental function</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abnormality of higher mental function</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0011675 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0011675">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arrhythmia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arrhythmia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0012417 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0012417">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypocapnia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypocapnia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0012418 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0012418">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypoxemia</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypoxemia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0012735 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0012735">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cough</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cough</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0020219 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0020219">
+        <rdfs:label>Motor seizure</rdfs:label>
+        <obo:IAO_0000111>Motor seizure</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0025143 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0025143">
+        <rdfs:label xml:lang="en">Chills</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">Chills</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0025144 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0025144">
+        <rdfs:label xml:lang="en">Shivering</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">Shivering</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0025145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0025145">
+        <rdfs:label xml:lang="en">Rigors</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">Rigors</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0025406 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0025406">
+        <rdfs:label xml:lang="en">Asthenia</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">Asthenia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0025439 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0025439">
+        <rdfs:label xml:lang="en">Pharyngitis</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">Pharyngitis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031245 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031245">
+        <rdfs:label>Productive cough</rdfs:label>
+        <obo:IAO_0000111>Productive cough</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031246 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031246">
+        <rdfs:label>Nonproductive cough</rdfs:label>
+        <obo:IAO_0000111>Nonproductive cough</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031249">
+        <rdfs:label>Parageusia</rdfs:label>
+        <obo:IAO_0000111>Parageusia</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031258 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031258">
+        <rdfs:label>Delirium</rdfs:label>
+        <obo:IAO_0000111>Delirium</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031352 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031352">
+        <rdfs:label>Chest tightness</rdfs:label>
+        <obo:IAO_0000111>Chest tightness</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0031417 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0031417">
+        <rdfs:label>Rhinorrhea</rdfs:label>
+        <obo:IAO_0000111>Rhinorrhea</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0100543 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0100543">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cognitive impairment</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cognitive impairment</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/HP_0100749 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/HP_0100749">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chest pain</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chest pain</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/hp.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_2697049 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2697049">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe acute respiratory syndrome coronavirus 2</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe acute respiratory syndrome coronavirus 2</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_452646 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_452646">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neovison vison</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neovison vison</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_58055 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58055">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinolophidae</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinolophidae</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_59477 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59477">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinolophus affinis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinolophus affinis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_8930 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8930">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Columbidae</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Columbidae</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9397 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9397">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chiroptera</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chiroptera</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9673 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9673">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Viverridae</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Viverridae</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9689 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9689">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panthera leo</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panthera leo</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9694 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9694">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panthera tigris</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panthera tigris</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9823 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9823">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sus scrofa</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sus scrofa</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9973 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9973">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manis</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manis</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9974 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9974">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manis javanica</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manis javanica</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C113122 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C113122">
+        <rdfs:label>Blood Collection Tube</rdfs:label>
+        <obo:IAO_0000111>Blood Collection Tube</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C113675 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C113675">
+        <rdfs:label>Serum Collection Tube</rdfs:label>
+        <obo:IAO_0000111>Serum Collection Tube</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C121416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C121416">
+        <rdfs:label>Loss of Fine Movements</rdfs:label>
+        <obo:IAO_0000111>Loss of Fine Movements</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C15429 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C15429">
+        <rdfs:label>Research Activity</rdfs:label>
+        <obo:IAO_0000111>Research Activity</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C17118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C17118">
+        <rdfs:label>School</rdfs:label>
+        <obo:IAO_0000111>School</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C17611 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C17611">
+        <rdfs:label>Bronchoscope</rdfs:label>
+        <obo:IAO_0000111>Bronchoscope</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C48950 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C48950">
+        <rdfs:label>Door</rdfs:label>
+        <obo:IAO_0000111>Door</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C53511 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C53511">
+        <rdfs:label>Intensive Care Unit</rdfs:label>
+        <obo:IAO_0000111>Intensive Care Unit</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C53513 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C53513">
+        <rdfs:label>Emergency Room</rdfs:label>
+        <obo:IAO_0000111>Emergency Room</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000844 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000844">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hospital</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hospital</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000869 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000869">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polyA RNA extract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polyA RNA extract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000880 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000880">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNA extract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNA extract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000895 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000895">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">total RNA extract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">total RNA extract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001128 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001128">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">micropipette</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">micropipette</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002600 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002600">
+        <rdfs:label>collecting specimen with swab</rdfs:label>
+        <obo:IAO_0000111>collecting specimen with swab</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002627 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002627">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ribosomal RNA-depleted RNA extract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ribosomal RNA-depleted RNA extract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002650 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002650">
+        <rdfs:label>biopsy</rdfs:label>
+        <obo:IAO_0000111>biopsy</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002651 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002651">
+        <rdfs:label>image guided biopsy</rdfs:label>
+        <obo:IAO_0000111>image guided biopsy</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002754 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002754">
+        <rdfs:label xml:lang="en">cDNA library</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">cDNA library</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050270 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050270">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host translation inhibitor nsp1 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host translation inhibitor nsp1 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050271 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050271">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 2 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 2 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050272 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050272">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 3 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 3 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050273 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050273">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 4 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 4 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050274 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050274">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3C-like proteinase (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3C-like proteinase (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050275 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050275">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 6 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 6 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050276 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050276">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 7 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 7 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050277 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050277">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 8 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 8 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050278 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050278">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 9 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 9 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050279 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050279">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 10 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 10 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050280">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 11 (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-structural protein 11 (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050281 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050281">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rep gene proteolytic cleavage product (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rep gene proteolytic cleavage product (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050284 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050284">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNA-directed RNA polymerase (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNA-directed RNA polymerase (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050285 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050285">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helicase (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helicase (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050286 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050286">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proofreading exoribonuclease (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proofreading exoribonuclease (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050287 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050287">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uridylate-specific endoribonuclease (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uridylate-specific endoribonuclease (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_000050288 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000050288">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2&#39;-O-methyltransferase (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2&#39;-O-methyltransferase (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_A0A663DJA2 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_A0A663DJA2">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF10 protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF10 protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC1-1 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC1-1">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">replicase polyprotein 1a (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">replicase polyprotein 1a (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC2 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC2">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spike glycoprotein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spike glycoprotein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC3 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC3">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF3a protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF3a protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC4 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC4">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">envelope small membrane protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">envelope small membrane protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC5 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC5">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">membrane protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">membrane protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC6 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC6">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF6 protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF6 protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC7 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC7">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF7a protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF7a protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTC8 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTC8">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF8 protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF8 protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTD2 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTD2">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF9b protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF9b protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PR_P0DTD8 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_P0DTD8">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF7b protein (SARS-CoV-2)</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ORF7b protein (SARS-CoV-2)</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/pr.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000173">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amniotic fluid</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amniotic fluid</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000912 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000912">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mucus</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mucus</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000970 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000970">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001087 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001087">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural fluid</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural fluid</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001089 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001089">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sweat</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sweat</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001245 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001245">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anus</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anus</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001557 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001557">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper respiratory tract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper respiratory tract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001558 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001558">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower respiratory tract</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower respiratory tract</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001827 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001827">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secretion of lacrimal gland</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secretion of lacrimal gland</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001913 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001913">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">milk</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">milk</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002169 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002169">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alveolar sac</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alveolar sac</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002186 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002186">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bronchiole</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bronchiole</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002402 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002402">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural cavity</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural cavity</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002409 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002409">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pericardial fluid</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pericardial fluid</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002453 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002453">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ethmoid sinus</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ethmoid sinus</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005921 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005921">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">middle nasal concha</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">middle nasal concha</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005922 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005922">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inferior nasal concha</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inferior nasal concha</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0006530 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006530">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seminal fluid</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seminal fluid</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0009778 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009778">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural sac</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleural sac</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0036243 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0036243">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vaginal fluid</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vaginal fluid</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_2001427 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_2001427">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anterior naris</rdfs:label>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anterior naris</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uberon.owl"/>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 1.3.5.1016) http://owlapi.sourceforge.net -->
+


### PR DESCRIPTION
Created the `canada_covid19.owl` file that imports terms CanCOGeN Covid19 picklist terms (pulled from the DataHarmonizer_Template spreadsheet) that have a corresponding ontology IDs.

Has been added to the `src/ontology/imports` folder and saved as a direct import for `genepio-edit.owl`.

Filtered out terms that are already present in other import files.