### PR TITLE
Chebi file adjustment

### DIFF
--- a/src/ontology/imports/chebi_import.owl
+++ b/src/ontology/imports/chebi_import.owl
@@ -1,19 +1,6 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY xml "http://www.w3.org/XML/1998/namespace" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-]>
-
-
-<rdf:RDF xmlns="&obo;genepio/imports/chebi_import.owl#"
-     xml:base="&obo;genepio/imports/chebi_import.owl"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/genepio/imports/chebi_import.owl#"
+     xml:base="http://purl.obolibrary.org/obo/genepio/imports/chebi_import.owl"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -21,7 +8,7 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="&obo;genepio/imports/chebi_import.owl"/>
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/genepio/imports/chebi_import.owl"/>
     
 
 
@@ -38,7 +25,7 @@
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115">
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
         <rdfs:label>definition</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -46,7 +33,7 @@
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000412">
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
         <rdfs:label xml:lang="en">imported from</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -54,15 +41,9 @@
 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasAlternativeId">
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId">
         <rdfs:label>has_alternative_id</rdfs:label>
     </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <owl:AnnotationProperty rdf:about="&rdfs;label"/>
     
 
 
@@ -79,24 +60,24 @@
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000023 -->
 
-    <owl:Class rdf:about="&obo;BFO_0000023"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023"/>
     
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000040 -->
 
-    <owl:Class rdf:about="&obo;BFO_0000040"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
     
 
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_100147 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_100147">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_73537"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <obo:IAO_0000115>A monocarboxylic acid comprising 1,8-naphthyridin-4-one substituted by carboxylic acid, ethyl and methyl groups at positions 3, 1, and 7, respectively. An orally administered antibacterial, it is used in the treatment of lower urinary-tract infections due to Gram-negative bacteria, including the majority of E. coli, Enterobacter, Klebsiella, and Proteus species.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_100147">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_73537"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <obo:IAO_0000115>A monocarboxylic acid comprising 1,8-naphthyridin-4-one substituted by carboxylic acid, ethyl and methyl groups at positions 3, 1, and 7, respectively. An orally administered antibacterial, it is used in the treatment of lower urinary-tract infections due to Gram-negative bacteria, including the majority of &lt;em&gt;E. coli&lt;/em&gt;, &lt;em&gt;Enterobacter&lt;/em&gt;, &lt;em&gt;Klebsiella&lt;/em&gt;, and &lt;em&gt;Proteus&lt;/em&gt; species.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:7456</oboInOwl:hasAlternativeId>
         <rdfs:label>nalidixic acid</rdfs:label>
     </owl:Class>
@@ -105,16 +86,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_100241 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_100241">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36709"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51454"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
-        <obo:IAO_0000115>A  quinolone that is quinolin-4(1H)-one bearing cyclopropyl, carboxylic acid, fluoro and piperazin-1-yl substituents at positions 1, 3, 6 and 7, respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_100241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36709"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51454"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
+        <obo:IAO_0000115>A  quinolone that is quinolin-4(1&lt;em&gt;H&lt;/em&gt;)-one bearing cyclopropyl, carboxylic acid, fluoro and piperazin-1-yl substituents at positions 1, 3, 6 and 7, respectively.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:102718</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3717</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41638</oboInOwl:hasAlternativeId>
@@ -125,14 +106,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_100246 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_100246">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_100246">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A quinolinemonocarboxylic acid with broad-spectrum antibacterial activity against most gram-negative and gram-positive bacteria. Norfloxacin is bactericidal and its mode of action depends on blocking of bacterial DNA replication by binding itself to an enzyme called DNA gyrase.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:7629</oboInOwl:hasAlternativeId>
         <rdfs:label>norfloxacin</rdfs:label>
     </owl:Class>
@@ -141,11 +122,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_102265 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_102265">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39447"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87228"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_102265">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39447"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87228"/>
         <obo:IAO_0000115>A sulfonamide consisting of pyrimidine with methyl substituents at the 4- and 6-positions and a 4-aminobenzenesulfonamido group at the 2-position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfamethazine</rdfs:label>
     </owl:Class>
     
@@ -153,11 +135,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_102484 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_102484">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55373"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87228"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_102484">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55373"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87228"/>
         <obo:IAO_0000115>A sulfonamide antibacterial with an oxazole substituent. It has antibiotic activity against a wide range of gram-negative and gram-positive organisms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:9343</oboInOwl:hasAlternativeId>
         <rdfs:label>sulfisoxazole</rdfs:label>
     </owl:Class>
@@ -166,14 +149,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_116278 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_116278">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_116278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A fluoroquinolone antibiotic, used (generally as the hydrochloride salt) to treat bacterial infections including bronchitis and urinary tract infections. It is also used to prevent urinary tract infections prior to surgery.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:6517</oboInOwl:hasAlternativeId>
         <rdfs:label>lomefloxacin</rdfs:label>
     </owl:Class>
@@ -182,15 +165,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_124991 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_124991">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26961"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50896"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_124991">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26961"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50896"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
         <obo:IAO_0000115>A semisynthetic, first-generation cephalosporin antibiotic with acetoxymethyl and (2-thienylacetyl)nitrilo moieties at positions 3 and 7, respectively, of the core structure. Administered parenterally during surgery and to treat a wide spectrum of blood infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:41547</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:50895</oboInOwl:hasAlternativeId>
         <rdfs:label>cefalotin</rdfs:label>
@@ -200,10 +183,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_131927 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_131927">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36586"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_131927">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
         <obo:IAO_0000115>A class of carbonyl compound encompassing dicarboxylic acids and any derivatives obtained by substitution of either one or both of the carboxy hydrogens.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dicarboxylic acids and O-substituted derivatives</rdfs:label>
     </owl:Class>
     
@@ -211,11 +194,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_13248 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_13248">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22712"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_62733"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_13248">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22712"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_62733"/>
         <obo:IAO_0000115>Any aromatic amide obtained by acylation of aniline.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>anilide</rdfs:label>
     </owl:Class>
     
@@ -223,9 +206,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_134742 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_134742">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26151"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_134742">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26151"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>delamanid</rdfs:label>
     </owl:Class>
     
@@ -233,10 +216,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_134958 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_134958">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_13248"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22160"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_134958">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_13248"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22160"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thioacetazone</rdfs:label>
     </owl:Class>
     
@@ -244,10 +227,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_135278 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_135278">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_135278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>terizidone</rdfs:label>
     </owl:Class>
     
@@ -255,10 +238,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_138675 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_138675">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33579"/>
-        <obo:IAO_0000115>Any main group molecular entity that is gaseous at standard temperature and pressure (STP; 0degreeC and 100 kPa).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_138675">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33579"/>
+        <obo:IAO_0000115>Any main group molecular entity that is gaseous at standard temperature and pressure (STP; 0°C and 100 kPa).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>gas molecular entity</rdfs:label>
     </owl:Class>
     
@@ -266,11 +249,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_139588 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_139588">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_52396"/>
-        <obo:IAO_0000115>An alpha-oxyketone that has a hydroxy group as the alpha-oxy moiety.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_139588">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17087"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33822"/>
+        <obo:IAO_0000115>A ketone containing a hydroxy group on the α-carbon relative to the C=O group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha-hydroxy ketone</rdfs:label>
     </owl:Class>
     
@@ -278,11 +261,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_139592 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_139592">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_139588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26878"/>
-        <obo:IAO_0000115>An alpha-hydroxy ketone in which the carbonyl group and the hydroxy group are linked by a carbon bearing two organyl groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_139592">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_139588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26878"/>
+        <obo:IAO_0000115>An α-hydroxy ketone in which the carbonyl group and the hydroxy group are linked by a carbon bearing two organyl groups.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tertiary alpha-hydroxy ketone</rdfs:label>
     </owl:Class>
     
@@ -290,10 +273,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_140325 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_140325">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>A carboxamide resulting from the formal condensation of a carboxylic acid with a primary amine; formula RC(=O)NHR(1).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_140325">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>A carboxamide resulting from the formal condensation of a carboxylic acid with a primary amine; formula RC(=O)NHR&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>secondary carboxamide</rdfs:label>
     </owl:Class>
     
@@ -301,10 +284,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_140326 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_140326">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>A carboxamide resulting from the formal condensation of a carboxylic acid with a secondary amine; formula RC(=O)NHR(1)R(2).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_140326">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>A carboxamide resulting from the formal condensation of a carboxylic acid with a secondary amine; formula RC(=O)NHR&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tertiary carboxamide</rdfs:label>
     </owl:Class>
     
@@ -312,10 +295,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_143084 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_143084">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_143084">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>A compound having bonds between one or more metalloid atoms and one or more carbon atoms of an organyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organometalloidal compound</rdfs:label>
     </owl:Class>
     
@@ -323,11 +306,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_146295 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_146295">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_146295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Any organic heterotricyclic compound whose core skeleton consists of a benzodioxin ring that is ortho-fused to a pyran ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyranobenzodioxin</rdfs:label>
     </owl:Class>
     
@@ -335,10 +318,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15369 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15369">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23239"/>
-        <obo:IAO_0000115>A large group of antibiotics isolated from various species of Streptomyces and characterised by having a substituted phenoxazine ring linked to two cyclic heterodetic peptides.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15369">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23239"/>
+        <obo:IAO_0000115>A large group of antibiotics isolated from various species of &lt;em&gt;Streptomyces&lt;/em&gt; and characterised by having a substituted phenoxazine ring linked to two cyclic heterodetic peptides.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13723</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22220</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2445</oboInOwl:hasAlternativeId>
@@ -349,15 +332,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15379 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15379">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_138675"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25362"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33263"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15379">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_138675"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25362"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:10745</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13416</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23833</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25366</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:29097</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:30491</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44742</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7860</oboInOwl:hasAlternativeId>
@@ -368,15 +352,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_157175 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_157175">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33709"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_73537"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_157175">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33709"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_73537"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A 1,8-naphthyridine derivative that is 1,4-dihydro-1,8-naphthyridine with an ethyl group at the 1 position, a carboxy group at the 3-position, an oxo sustituent at the 4-position, a fluoro substituent at the 5-position and a piperazin-1-yl group at the 7 position. An antibacterial, it is used in the treatment of urinary-tract infections and gonorrhoea.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:4796</oboInOwl:hasAlternativeId>
         <rdfs:label>enoxacin</rdfs:label>
     </owl:Class>
@@ -385,10 +369,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15734 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15734">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <obo:IAO_0000115>A primary alcohol is a compound in which a hydroxy group, -OH, is attached to a saturated carbon atom which has either three hydrogen atoms attached to it or only one other carbon atom and two hydrogen atoms attached to it.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15734">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+        <obo:IAO_0000115>A primary alcohol is a compound in which a hydroxy group, ‒OH, is attached to a saturated carbon atom which has either three hydrogen atoms attached to it or only one other carbon atom and two hydrogen atoms attached to it.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13676</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:14887</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26262</oboInOwl:hasAlternativeId>
@@ -401,11 +385,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15782 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15782">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24533"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <obo:IAO_0000115>A cyclic peptide antibiotic produced by the actinomycete Streptomyces puniceus, used in the treatment of tuberculosis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15782">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24533"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <obo:IAO_0000115>A cyclic peptide antibiotic produced by the actinomycete &lt;em&gt;Streptomyces&lt;/em&gt; &lt;em&gt;puniceus&lt;/em&gt;, used in the treatment of tuberculosis.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:15312</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:27296</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:579539</oboInOwl:hasAlternativeId>
@@ -417,11 +401,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15841 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15841">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33839"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15841">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33839"/>
         <obo:IAO_0000115>A peptide containing ten or more amino acid residues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14860</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8314</oboInOwl:hasAlternativeId>
         <rdfs:label>polypeptide</rdfs:label>
@@ -431,11 +415,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_15986 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_15986">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33695"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_61120"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15986">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33695"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_61120"/>
         <obo:IAO_0000115>A nucleobase-containing molecular entity with a polymeric structure comprised of a linear sequence of 13 or more nucleotide residues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13672</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:14859</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8312</oboInOwl:hasAlternativeId>
@@ -446,11 +430,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_161680 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_161680">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50695"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A synthetic monocyclic beta-lactam antibiotic (monobactam), used primarily to treat infections caused by Gram-negative bacteria. It inhibits mucopeptide synthesis in the bacterial cell wall, thereby blocking peptidoglycan crosslinking.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_161680">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50695"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A synthetic monocyclic β-lactam antibiotic (monobactam), used primarily to treat infections caused by Gram-negative bacteria. It inhibits mucopeptide synthesis in the bacterial cell wall, thereby blocking peptidoglycan crosslinking.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:2960</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41008</oboInOwl:hasAlternativeId>
         <rdfs:label>aztreonam</rdfs:label>
@@ -460,12 +444,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16247 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16247">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_18059"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25703"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37734"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16247">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18059"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25703"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37734"/>
         <obo:IAO_0000115>A lipid containing phosphoric acid as a mono- or di-ester. The term encompasses phosphatidic acids and phosphoglycerides.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14816</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26063</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8150</oboInOwl:hasAlternativeId>
@@ -476,12 +460,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16301 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16301">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33458"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_62764"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_79389"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16301">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33458"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_62764"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_79389"/>
         <obo:IAO_0000115>The nitrogen oxoanion formed by loss of a proton from nitrous acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14658</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44396</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7585</oboInOwl:hasAlternativeId>
@@ -492,11 +476,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16385 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16385">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26822"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <obo:IAO_0000115>Compounds having the structure RSR (R =/= H). Such compounds were once called thioethers.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16385">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26822"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <obo:IAO_0000115>Compounds having the structure RSR (R ≠ H). Such compounds were once called thioethers.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13694</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26960</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9340</oboInOwl:hasAlternativeId>
@@ -507,13 +491,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_164200 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_164200">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23697"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35618"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83403"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_164200">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23697"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83403"/>
         <obo:IAO_0000115>An aromatic ether that is phenol which is substituted at C-5 by a chloro group and at C-2 by a 2,4-dichlorophenoxy group. It is widely used as a preservative and antimicrobial agent in personal care products such as soaps, skin creams, toothpaste and deodorants as well as in household items such as plastic chopping boards, sports equipment and shoes.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:29697</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:47700</oboInOwl:hasAlternativeId>
         <rdfs:label>triclosan</rdfs:label>
@@ -523,10 +507,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16449 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16449">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33704"/>
-        <obo:IAO_0000115>An alpha-amino acid that consists of propionic acid bearing an amino substituent at position 2.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33704"/>
+        <obo:IAO_0000115>An α-amino acid that consists of propionic acid bearing an amino substituent at position 2.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13748</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22277</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2539</oboInOwl:hasAlternativeId>
@@ -537,10 +521,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16541 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16541">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_15841"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16541">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15841"/>
         <obo:IAO_0000115>A naturally occurring polypeptide synthesized at the ribosome.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:8526</oboInOwl:hasAlternativeId>
         <rdfs:label>protein polypeptide chain</rdfs:label>
     </owl:Class>
@@ -549,11 +533,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16670 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16670">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
-        <obo:IAO_0000115>Amide derived from two or more amino carboxylic acid molecules (the same or different) by formation of a covalent bond from the carbonyl carbon of one to the nitrogen atom of another with formal loss of water. The term is usually applied to structures formed from alpha-amino acids, but it includes those derived from any amino carboxylic acid. X = OH, OR, NH2, NHR, etc.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16670">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
+        <obo:IAO_0000115>Amide derived from two or more amino carboxylic acid molecules (the same or different) by formation of a covalent bond from the carbonyl carbon of one to the nitrogen atom of another with formal loss of water. The term is usually applied to structures formed from α-amino acids, but it includes those derived from any amino carboxylic acid. X = OH, OR, NH2, NHR, etc.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14753</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25906</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7990</oboInOwl:hasAlternativeId>
@@ -564,10 +548,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_167559 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_167559">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_78616"/>
-        <obo:IAO_0000115>Any oligosaccharide, polysaccharide or their derivatives consisting of monosaccharides or monosaccharide derivatives linked by glycosidic bonds. See also http://www.ontobee.org/ontology/GNO?iri=http://purl.obolibrary.org/obo/GNO_00000001.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_167559">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_78616"/>
+        <obo:IAO_0000115>Any oligosaccharide, polysaccharide or their derivatives consisting of monosaccharides or monosaccharide derivatives linked by glycosidic bonds. See also &lt;a href=&quot;http://www.ontobee.org/ontology/GNO?iri=http://purl.obolibrary.org/obo/GNO_00000001&quot; target=&quot;_blank&quot;&gt;http://www.ontobee.org/ontology/GNO?iri=http://purl.obolibrary.org/obo/GNO_00000001&lt;/a&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>glycan</rdfs:label>
     </owl:Class>
     
@@ -575,9 +559,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16869 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16869">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25661"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16869">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25661"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14682</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25659</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7737</oboInOwl:hasAlternativeId>
@@ -588,10 +572,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_16991 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_16991">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33696"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16991">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33696"/>
         <obo:IAO_0000115>High molecular weight, linear polymers, composed of nucleotides containing deoxyribose and linked by phosphodiester bonds; DNA contain the genetic information of organisms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13302</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:21123</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:33698</oboInOwl:hasAlternativeId>
@@ -603,12 +587,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17076 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17076">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26788"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87113"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87114"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17076">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26788"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87113"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87114"/>
         <obo:IAO_0000115>A amino cyclitol glycoside that consists of streptidine having a disaccharyl moiety attached at the 4-position. The parent of the streptomycin class</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:15119</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26784</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:45745</oboInOwl:hasAlternativeId>
@@ -620,10 +604,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17087 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17087">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36586"/>
-        <obo:IAO_0000115>A compound in which a carbonyl group is bonded to two carbon atoms: R2C=O (neither R may be H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17087">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
+        <obo:IAO_0000115>A compound in which a carbonyl group is bonded to two carbon atoms: R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C=O (neither R may be H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13427</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13646</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:24974</oboInOwl:hasAlternativeId>
@@ -636,12 +620,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17154 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17154">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_176839"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25529"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26416"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17154">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_176839"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25529"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26416"/>
         <obo:IAO_0000115>A pyridinecarboxamide that is pyridine in which the hydrogen at position 3 is replaced by a carboxamide group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14645</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25521</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44258</oboInOwl:hasAlternativeId>
@@ -653,10 +637,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17334 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17334">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25865"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17334">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25865"/>
         <obo:IAO_0000115>Any member of the group of substituted penams containing two methyl substituents at position 2, a carboxylate substituent at position 3 and a carboxamido group at position 6.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14742</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25869</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7961</oboInOwl:hasAlternativeId>
@@ -667,14 +651,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17478 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17478">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36586"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17478">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
         <obo:IAO_0000115>A compound RC(=O)H, in which a carbonyl group is bonded to one hydrogen atom and to one R group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13432</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13753</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13805</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13806</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:17496</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22291</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2554</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8750</oboInOwl:hasAlternativeId>
@@ -685,12 +670,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17630 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17630">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24951"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17630">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24951"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14487</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:24945</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:24947</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:28008</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:43482</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:6106</oboInOwl:hasAlternativeId>
         <rdfs:label>kanamycin A</rdfs:label>
@@ -700,12 +686,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17632 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17632">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33458"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_62764"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_79389"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17632">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33458"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_62764"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_79389"/>
         <obo:IAO_0000115>A nitrogen oxoanion formed by loss of a proton from nitric acid. Principal species present at pH 7.3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14654</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44487</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:71263</oboInOwl:hasAlternativeId>
@@ -716,15 +702,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17658 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17658">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17478"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25022"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51689"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63353"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63367"/>
-        <obo:IAO_0000115>A macrolide antibiotic that is tylonolide having mono- and diglycosyl moieties attached to two of its hydroxy groups. It is found naturally as a fermentation product of Streptomyces fradiae.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17658">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25022"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63353"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63367"/>
+        <obo:IAO_0000115>A macrolide antibiotic that is tylonolide having mono- and diglycosyl moieties attached to two of its hydroxy groups. It is found naturally as a fermentation product of &lt;em&gt;Streptomyces fradiae&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:15275</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:27172</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:46150</oboInOwl:hasAlternativeId>
@@ -736,10 +722,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_176839 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_176839">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_75769"/>
-        <obo:IAO_0000115>Any member of a group of vitamers that belong to the chemical structural class called pyridines that exhibit biological activity against vitamin B3 deficiency. Vitamin B3 deficiency causes a condition known as pellagra whose symptoms include depression, dermatitis and diarrhea. The vitamers include nicotinic acid and nicotinamide (and their ionized and salt forms).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_176839">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_75769"/>
+        <obo:IAO_0000115>Any member of a group of vitamers that belong to the chemical structural class called pyridines that exhibit biological activity against vitamin B&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt; deficiency. Vitamin B&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt; deficiency causes a condition known as &lt;a href=&quot;https://en.wikipedia.org/wiki/Pellagra&quot; target=&quot;_blank&quot;&gt;pellagra&lt;/a&gt; whose symptoms include depression, dermatitis and diarrhea. The vitamers include nicotinic acid and nicotinamide (and their ionized and salt forms).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>vitamin B3</rdfs:label>
     </owl:Class>
     
@@ -747,13 +733,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17698 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17698">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23824"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35716"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36683"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17698">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23824"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35716"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36683"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
         <obo:IAO_0000115>An organochlorine compound that is dichloro-substituted acetamide containing a nitrobenzene ring, an amide bond and two alcohol functions.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13965</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23106</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23108</oboInOwl:hasAlternativeId>
@@ -766,11 +752,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17792 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17792">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37578"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17792">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37578"/>
         <obo:IAO_0000115>A compound containing at least one carbon-halogen bond (where X is a halogen atom).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13444</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:36684</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8767</oboInOwl:hasAlternativeId>
@@ -781,10 +767,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_17939 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_17939">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26404"/>
-        <obo:IAO_0000115>An aminonucleoside antibiotic, derived from the Streptomyces alboniger bacterium, that causes premature chain termination during translation taking place in the ribosome.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17939">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26404"/>
+        <obo:IAO_0000115>An aminonucleoside antibiotic, derived from the &lt;em&gt;Streptomyces alboniger&lt;/em&gt; bacterium, that causes premature chain termination during translation taking place in the ribosome.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14970</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26402</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:45182</oboInOwl:hasAlternativeId>
@@ -796,10 +782,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18059 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18059">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18059">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>&apos;Lipids&apos; is a loosely defined term for substances of biological origin that are soluble in nonpolar solvents. They consist of saponifiable lipids, such as glycerides (fats and oils) and phospholipids, as well as nonsaponifiable lipids, principally steroids.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14517</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25054</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:6486</oboInOwl:hasAlternativeId>
@@ -810,10 +796,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18111 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18111">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33697"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18111">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33697"/>
         <obo:IAO_0000115>RNA molecules which are essential structural and functional components of ribosomes, the subcellular units responsible for protein synthesis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:10636</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:15010</oboInOwl:hasAlternativeId>
         <rdfs:label>ribosomal RNA</rdfs:label>
@@ -823,9 +809,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18165 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18165">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17334"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18165">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14472</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:43447</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:6036</oboInOwl:hasAlternativeId>
@@ -836,9 +822,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18203 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18203">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17334"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18203">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14744</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25867</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7964</oboInOwl:hasAlternativeId>
@@ -849,10 +835,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18208 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18208">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18208">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a phenylacetamido group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:14743</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25866</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:45073</oboInOwl:hasAlternativeId>
@@ -864,11 +851,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_18254 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_18254">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33838"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47019"/>
-        <obo:IAO_0000115>Any nucleoside where the sugar component is D-ribose.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18254">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33838"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47019"/>
+        <obo:IAO_0000115>Any nucleoside where the sugar component is &lt;small&gt;D&lt;/small&gt;-ribose.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13014</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13015</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13685</oboInOwl:hasAlternativeId>
@@ -883,9 +870,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_19129 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_19129">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36841"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_19129">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36841"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>11alpha-hydroxy steroid</rdfs:label>
     </owl:Class>
     
@@ -893,14 +880,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_194135 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_194135">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37143"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46920"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47881"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_53665"/>
-        <obo:IAO_0000115>An oxazinoquinoline that is 2,3-dihydro-7H-[1,4]oxazino[2,3,4-ij]quinolin-7-one substituted by methyl, carboxy, fluoro, and 4-methylpiperazin-1-yl groups at positions 3, 6, 9, and 10, respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_194135">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37143"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46920"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47881"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_53665"/>
+        <obo:IAO_0000115>An oxazinoquinoline that is 2,3-dihydro-7&lt;em&gt;H&lt;/em&gt;-[1,4]oxazino[2,3,4-&lt;em&gt;ij&lt;/em&gt;]quinolin-7-one substituted by methyl, carboxy, fluoro, and 4-methylpiperazin-1-yl groups at positions 3, 6, 9, and 10, respectively.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>9-fluoro-3-methyl-10-(4-methylpiperazin-1-yl)-7-oxo-2,3-dihydro-7H-[1,4]oxazino[2,3,4-ij]quinoline-6-carboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -908,12 +895,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_204928 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_204928">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36816"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38418"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_204928">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36816"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38418"/>
         <obo:IAO_0000115>A cephalosporin compound having acetoxymethyl and [2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetyl]amino side groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:112504</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3497</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41475</oboInOwl:hasAlternativeId>
@@ -924,13 +911,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_209807 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_209807">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55429"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A semisynthetic cephamycin antibiotic which, in addition to the methoxy group at the 7alpha position, has 2-thienylacetamido and carbamoyloxymethyl side-groups. It is resistant to beta-lactamase.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_209807">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55429"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A semisynthetic cephamycin antibiotic which, in addition to the methoxy group at the 7α position, has 2-thienylacetamido and carbamoyloxymethyl side-groups. It is resistant to β-lactamase.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3500</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41436</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:471714</oboInOwl:hasAlternativeId>
@@ -942,11 +929,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_21731 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_21731">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63161"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_21731">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63161"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A glycosyl compound arising formally from the elimination of water from a glycosidic hydroxy group and an H atom bound to a nitrogen atom, thus creating a C-N bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-glycosyl compound</rdfs:label>
     </owl:Class>
     
@@ -954,10 +942,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22160 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22160">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>Compounds with the general formula RNHC(=O)CH3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22160">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>Compounds with the general formula RNHC(=O)CH&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>acetamides</rdfs:label>
     </owl:Class>
     
@@ -965,9 +953,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22213 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22213">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39206"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39206"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>acridines</rdfs:label>
     </owl:Class>
     
@@ -975,10 +963,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22260 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22260">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26399"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26399"/>
         <obo:IAO_0000115>Any purine ribonucleoside that is a derivative of adenosine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>adenosines</rdfs:label>
     </owl:Class>
     
@@ -986,10 +974,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22315 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22315">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22315">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
         <obo:IAO_0000115>Any of the naturally occurring, basic nitrogen compounds (mostly heterocyclic) occurring mostly in the plant kingdom, but also found in bacteria, fungi, and animals. By extension, certain neutral compounds biogenetically related to basic alkaloids are also classed as alkaloids. Amino acids, peptides, proteins, nucleotides, nucleic acids, amino sugars and antibiotics are not normally regarded as alkaloids. Compounds in which the nitrogen is  exocyclic (dopamine, mescaline, serotonin, etc.) are usually classed as amines rather than alkaloids.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alkaloid</rdfs:label>
     </owl:Class>
     
@@ -997,10 +985,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22390 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22390">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35436"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_60979"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22390">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35436"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_60979"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha-D-glucoside</rdfs:label>
     </owl:Class>
     
@@ -1008,11 +996,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22478 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22478">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22478">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>An alcohol containing an amino functional group in addition to the alcohol-defining hydroxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>amino alcohol</rdfs:label>
     </owl:Class>
     
@@ -1020,10 +1008,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22479 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22479">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23451"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22479">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23451"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>amino cyclitol glycoside</rdfs:label>
     </owl:Class>
     
@@ -1031,10 +1019,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22495 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22495">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22723"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33856"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22495">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22723"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33856"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aminobenzoic acid</rdfs:label>
     </owl:Class>
     
@@ -1042,10 +1030,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22507 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22507">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23007"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47779"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22507">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23007"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47779"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aminoglycoside antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1053,11 +1041,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22562 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22562">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22712"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22562">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22712"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33860"/>
         <obo:IAO_0000115>Any  aromatic amine that is benzene carrying at least one amino substituent and its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>anilines</rdfs:label>
     </owl:Class>
     
@@ -1065,10 +1053,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22563 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22563">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24870"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22563">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24870"/>
         <obo:IAO_0000115>A monoatomic or polyatomic species having one or more elementary charges of the electron.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>anion</rdfs:label>
     </owl:Class>
     
@@ -1076,12 +1064,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22565 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22565">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24995"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26188"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51026"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22565">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26188"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
         <obo:IAO_0000115>A class of macrocyclic lactams that consist of an aromatic (phenyl or naphthyl) or quinonoid (benzoquinone or naphthoquinone) moiety that is bridged by an aliphatic chain.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ansamycin</rdfs:label>
     </owl:Class>
     
@@ -1089,17 +1077,17 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22582 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22582">
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22582">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
     </owl:Class>
     
 
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22632 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22632">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33302"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22632">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>arsenic molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1107,10 +1095,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22712 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22712">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33836"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22712">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33836"/>
         <obo:IAO_0000115>Any benzenoid aromatic compound consisting of the benzene skeleton and its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>benzenes</rdfs:label>
     </owl:Class>
     
@@ -1118,11 +1106,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22723 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22723">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22712"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33859"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22723">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22712"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33859"/>
         <obo:IAO_0000115>Any aromatic carboxylic acid that consists of benzene in which at least a single hydrogen has been substituted by a carboxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>benzoic acids</rdfs:label>
     </owl:Class>
     
@@ -1130,10 +1118,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22727 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22727">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>benzopyran</rdfs:label>
     </owl:Class>
     
@@ -1141,11 +1129,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22907 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22907">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23089"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <obo:IAO_0000115>A glycopeptide produced by the bacterium Streptomyces verticillus. The term, &apos;bleomycin&apos; refers to a family of structurally related compounds. When used as an anti-cancer agent, the chemotherapeutical forms are primarily bleomycin A2 and B2.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22907">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23089"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <obo:IAO_0000115>A glycopeptide produced by the bacterium &lt;em&gt;Streptomyces verticillus&lt;/em&gt;. The term, &apos;bleomycin&apos; refers to a family of structurally related compounds. When used as an anti-cancer agent, the chemotherapeutical forms are primarily bleomycin A&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; and B&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:584977</oboInOwl:hasAlternativeId>
         <rdfs:label>bleomycin</rdfs:label>
     </owl:Class>
@@ -1154,9 +1142,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22928 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22928">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24471"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22928">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24471"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>bromine molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1164,9 +1152,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_22985 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_22985">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33299"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22985">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33299"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>calcium molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1174,10 +1162,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23003 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23003">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <obo:IAO_0000115>Any ester of carbamic acid or its N-substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <obo:IAO_0000115>Any ester of carbamic acid or its &lt;em&gt;N&lt;/em&gt;-substituted derivatives.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbamate ester</rdfs:label>
     </owl:Class>
     
@@ -1185,10 +1173,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23007 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23007">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>Any carbohydrate derivative that exhibits antibiotic activity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbohydrate-containing antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1196,10 +1184,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23066 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23066">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38311"/>
-        <obo:IAO_0000115>A class of beta-lactam antibiotics differing from the penicillins in having a 6-membered, rather than a 5-membered, side ring.  Although cephalosporins are among the most commonly used antibiotics in the treatment of routine infections, and their use is increasing over time, they can cause a range of hypersensitivity reactions, from mild, delayed-onset cutaneous reactions to life-threatening anaphylaxis in patients with immunoglobulin E (IgE)-mediated allergy.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23066">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38311"/>
+        <obo:IAO_0000115>A class of β-lactam antibiotics differing from the penicillins in having a 6-membered, rather than a 5-membered, side ring.  Although cephalosporins are among the most commonly used antibiotics in the treatment of routine infections, and their use is increasing over time, they can cause a range of hypersensitivity reactions, from mild, delayed-onset cutaneous reactions to life-threatening anaphylaxis in patients with immunoglobulin E (IgE)-mediated allergy.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3538</oboInOwl:hasAlternativeId>
         <rdfs:label>cephalosporin</rdfs:label>
     </owl:Class>
@@ -1208,9 +1196,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23089 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23089">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23089">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chelate-forming peptide</rdfs:label>
     </owl:Class>
     
@@ -1218,10 +1206,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23114 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23114">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23117"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33958"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23117"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33958"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chloride salt</rdfs:label>
     </owl:Class>
     
@@ -1229,10 +1217,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23117 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23117">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24471"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24471"/>
         <obo:IAO_0000115>A halogen molecular entity containing one or more atoms of chlorine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chlorine molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1240,11 +1228,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23132 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23132">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22712"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36683"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23132">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22712"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36683"/>
         <obo:IAO_0000115>Any organochlorine compound containing a benzene ring which is substituted by one or more chlorines.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chlorobenzenes</rdfs:label>
     </owl:Class>
     
@@ -1252,9 +1240,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23232 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23232">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38443"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38443"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chromenes</rdfs:label>
     </owl:Class>
     
@@ -1262,9 +1250,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23239 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23239">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23239">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chromopeptide</rdfs:label>
     </owl:Class>
     
@@ -1272,10 +1260,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23367 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23367">
-        <rdfs:subClassOf rdf:resource="&obo;BFO_0000040"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
         <obo:IAO_0000115>Any constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer etc., identifiable as a separately distinguishable entity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1283,10 +1271,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23403 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23403">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26004"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38445"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23403">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38445"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>coumarins</rdfs:label>
     </owl:Class>
     
@@ -1294,9 +1282,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23443 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23443">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32988"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23443">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32988"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3990</oboInOwl:hasAlternativeId>
         <rdfs:label>cyclic amide</rdfs:label>
     </owl:Class>
@@ -1305,9 +1293,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23449 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23449">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic peptide</rdfs:label>
     </owl:Class>
     
@@ -1315,10 +1303,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23451 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23451">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26191"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23451">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26191"/>
         <obo:IAO_0000115>A polyol consisting of a cycloalkane containing at least three hydroxy groups, each attached to a different ring carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclitol</rdfs:label>
     </owl:Class>
     
@@ -1326,13 +1314,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23503 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23503">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26649"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38329"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50994"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_75606"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23503">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26649"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38329"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50994"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_75606"/>
         <obo:IAO_0000115>A member of the class of oxazolidines that is isoxazoldin-3-one which is substituted at position 4 by an amino group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>4-amino-1,2-oxazolidin-3-one</rdfs:label>
     </owl:Class>
     
@@ -1340,10 +1328,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23643 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23643">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
-        <obo:IAO_0000115>A natural or synthetic compound having a sequence of amino and hydroxy carboxylic acid residues (usually alpha-amino and alpha-hydroxy acids), commonly but not necessarily regularly alternating.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23643">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
+        <obo:IAO_0000115>A natural or synthetic compound having a sequence of amino and hydroxy carboxylic acid residues (usually α-amino and α-hydroxy acids), commonly but not necessarily regularly alternating.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>depsipeptide</rdfs:label>
     </owl:Class>
     
@@ -1351,10 +1339,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23677 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23677">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23677">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole that is either one of a pair of heterocyclic organic compounds comprising three carbon atoms and two nitrogen atoms arranged in a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diazole</rdfs:label>
     </owl:Class>
     
@@ -1362,10 +1350,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23697 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23697">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23132"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23697">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23132"/>
         <obo:IAO_0000115>Any member of the class of chlorobenzenes carrying two chloro groups at unspecified positions.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dichlorobenzene</rdfs:label>
     </owl:Class>
     
@@ -1373,11 +1361,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23763 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23763">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23763">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any organic heteromonocyclic compound with a structure based on a dihydropyrrole.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyrroline</rdfs:label>
     </owl:Class>
     
@@ -1385,9 +1373,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23765 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23765">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23765">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>quinolone</rdfs:label>
     </owl:Class>
     
@@ -1395,10 +1383,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23824 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23824">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26191"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23824">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26191"/>
         <obo:IAO_0000115>A compound that contains two hydroxy groups, generally assumed to be, but not necessarily, alcoholic. Aliphatic diols are also called glycols.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diol</rdfs:label>
     </owl:Class>
     
@@ -1406,9 +1394,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23953 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23953">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23953">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>erythromycins</rdfs:label>
     </owl:Class>
     
@@ -1416,9 +1404,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_23981 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23981">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22478"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23981">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22478"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ethanolamines</rdfs:label>
     </owl:Class>
     
@@ -1426,9 +1414,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24062 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24062">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24471"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24471"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>fluorine molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1436,11 +1424,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24129 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24129">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24129">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Compounds containing at least one furan ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>furans</rdfs:label>
     </owl:Class>
     
@@ -1448,9 +1436,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24278 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24278">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35313"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35313"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>glucoside</rdfs:label>
     </owl:Class>
     
@@ -1458,11 +1446,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24396 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24396">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24396">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>Any carbohydrate derivative that consists of glycan moieties covalently attached to the side chains of the amino acid residues that constitute the peptide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24395</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:5478</oboInOwl:hasAlternativeId>
         <rdfs:label>glycopeptide</rdfs:label>
@@ -1472,11 +1460,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24397 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24397">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16247"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33563"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24397">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16247"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33563"/>
         <obo:IAO_0000115>Any phospholipid that contain both phosphate and carbohydrate as integral structural components.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>glycophospholipid</rdfs:label>
     </owl:Class>
     
@@ -1484,10 +1472,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24400 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24400">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63161"/>
-        <obo:IAO_0000115>A glycosyl compound resulting from the attachment of a glycosyl group to a non-acyl group RO-, RS-, RSe-, etc. The bond between the glycosyl group and the non-acyl group is called a glycosidic bond. By extension, the terms N-glycosides and C-glycosides are used as class names for glycosylamines and for compounds having a glycosyl group attached to a hydrocarbyl group respectively. These terms are misnomers and should not be used. The preferred terms are glycosylamines and C-glycosyl compounds, respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24400">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63161"/>
+        <obo:IAO_0000115>A glycosyl compound resulting from the attachment of a glycosyl group to a non-acyl group RO‒, RS‒, RSe‒, etc. The bond between the glycosyl group and the non-acyl group is called a glycosidic bond. By extension, the terms &lt;em&gt;N&lt;/em&gt;-glycosides and &lt;em&gt;C&lt;/em&gt;-glycosides are used as class names for glycosylamines and for compounds having a glycosyl group attached to a hydrocarbyl group respectively. These terms are misnomers and should not be used. The preferred terms are glycosylamines and &lt;em&gt;C&lt;/em&gt;-glycosyl compounds, respectively.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>glycoside</rdfs:label>
     </owl:Class>
     
@@ -1495,9 +1483,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24431 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24431">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
         <obo:IAO_0000115>A chemical entity is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chemical entity</rdfs:label>
     </owl:Class>
     
@@ -1505,10 +1494,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24432 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24432">
-        <rdfs:subClassOf rdf:resource="&obo;BFO_0000023"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24432">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
         <obo:IAO_0000115>A role played by the molecular entity or part thereof within a biological context.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>biological role</rdfs:label>
     </owl:Class>
     
@@ -1516,9 +1505,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24471 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24471">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33675"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24471">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33675"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>halogen molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1526,9 +1515,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24531 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24531">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24531">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterocyclic antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1536,12 +1525,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24532 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24532">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33832"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5686"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24532">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33832"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5686"/>
         <obo:IAO_0000115>A cyclic compound having as ring members atoms of carbon and at least of one other element.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heterocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -1549,10 +1538,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24533 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24533">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23449"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24533">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23449"/>
         <obo:IAO_0000115>A heterodetic cyclic peptide is a peptide consisting only of amino-acid residues, but in which the linkages forming the ring are not solely peptide bonds; one or more is an isopeptide, disulfide, ester, or other bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterodetic cyclic peptide</rdfs:label>
     </owl:Class>
     
@@ -1560,10 +1549,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24613 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24613">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23449"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24613">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23449"/>
         <obo:IAO_0000115>A homodetic cyclic peptide is a cyclic peptide in which the ring consists solely of amino-acid residues in peptide linkages.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>homodetic cyclic peptide</rdfs:label>
     </owl:Class>
     
@@ -1571,10 +1560,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24628 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24628">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55370"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24628">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55370"/>
         <obo:IAO_0000115>An imidazolidinone with oxo groups at position 2 and 4.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imidazolidine-2,4-dione</rdfs:label>
     </owl:Class>
     
@@ -1582,10 +1571,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24650 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24650">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>A compound, RkE(=O)lNHOH, derived from an oxoacid RkE(=O)l(OH) (l =/= 0) by replacing -OH with -NHOH, and derivatives thereof. Specific examples of hydroxamic acids are preferably named as N-hydroxy amides.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24650">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>A compound, R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;NHOH, derived from an oxoacid R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH) (&lt;em&gt;l&lt;/em&gt; ≠ 0) by replacing ‒OH with ‒NHOH, and derivatives thereof. Specific examples of hydroxamic acids are preferably named as &lt;em&gt;N&lt;/em&gt;-hydroxy amides.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydroxamic acid</rdfs:label>
     </owl:Class>
     
@@ -1593,12 +1582,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24651 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24651">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25806"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33608"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
-        <obo:IAO_0000115>Hydroxides are chemical compounds containing a hydroxy group or salts containing hydroxide (OH(-)).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24651">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33608"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
+        <obo:IAO_0000115>Hydroxides are chemical compounds containing a hydroxy group or salts containing hydroxide (OH&lt;small&gt;&lt;sup&gt;−&lt;/small&gt;&lt;/sup&gt;).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydroxides</rdfs:label>
     </owl:Class>
     
@@ -1606,11 +1595,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24676 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24676">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22723"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24676">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22723"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
         <obo:IAO_0000115>Any benzoic acid carrying one or more phenolic hydroxy groups on the benzene ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:50778</oboInOwl:hasAlternativeId>
         <rdfs:label>hydroxybenzoic acid</rdfs:label>
     </owl:Class>
@@ -1619,10 +1608,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24780 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24780">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23677"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24780">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23677"/>
         <obo:IAO_0000115>A five-membered organic heterocycle containing two nitrogen atoms at positions 1 and 3, or any of its derivatives; compounds containing an imidazole skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imidazoles</rdfs:label>
     </owl:Class>
     
@@ -1630,9 +1619,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24782 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24782">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33257"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24782">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33257"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imide</rdfs:label>
     </owl:Class>
     
@@ -1640,10 +1629,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24833 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24833">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24651"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24833">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24651"/>
         <obo:IAO_0000115>A compound which contains oxygen, at least one other element, and at least one hydrogen bound to oxygen, and which produces a conjugate base by loss of positive hydrogen ion(s) (hydrons).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxoacid</rdfs:label>
     </owl:Class>
     
@@ -1651,10 +1640,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24834 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24834">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22563"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36914"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24834">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22563"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36914"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>inorganic anion</rdfs:label>
     </owl:Class>
     
@@ -1662,10 +1651,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24835 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24835">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24835">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>A molecular entity that contains no carbon.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>inorganic molecular entity</rdfs:label>
     </owl:Class>
     
@@ -1673,10 +1662,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24866 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24866">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24866">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
         <obo:IAO_0000115>A salt is an assembly of cations and anions.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>salt</rdfs:label>
     </owl:Class>
     
@@ -1684,9 +1673,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24868 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24868">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24866"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24868">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24866"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic salt</rdfs:label>
     </owl:Class>
     
@@ -1694,10 +1683,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24870 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24870">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24870">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>A molecular entity having a net electric charge.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ion</rdfs:label>
     </owl:Class>
     
@@ -1705,10 +1694,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24951 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24951">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24951">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>kanamycins</rdfs:label>
     </owl:Class>
     
@@ -1716,10 +1705,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24983 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24983">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25750"/>
-        <obo:IAO_0000115>Oximes of ketones R2C=NOH (where R =/= H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24983">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25750"/>
+        <obo:IAO_0000115>Oximes of ketones R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C=NOH (where R ≠ H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ketoxime</rdfs:label>
     </owl:Class>
     
@@ -1727,12 +1716,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_24995 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_24995">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23443"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24995">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23443"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Cyclic amides of amino carboxylic acids, having a 1-azacycloalkan-2-one structure, or analogues having unsaturation or heteroatoms replacing one or more carbon atoms of the ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lactam</rdfs:label>
     </owl:Class>
     
@@ -1740,11 +1729,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25000 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25000">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Any cyclic carboxylic ester containing a 1-oxacycloalkan-2-one structure, or an analogue having unsaturation or heteroatoms replacing one or more carbon atoms of the ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lactone</rdfs:label>
     </owl:Class>
     
@@ -1752,9 +1742,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25022 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25022">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25022">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>leucomycin</rdfs:label>
     </owl:Class>
     
@@ -1762,10 +1752,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25061 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25061">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46895"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46895"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lipopeptide antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1773,10 +1763,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25105 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25105">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
         <obo:IAO_0000115>A macrocyclic lactone with a ring of twelve or more members which exhibits antibiotic activity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>macrolide antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1784,11 +1774,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25106 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25106">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26188"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63944"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25106">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26188"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63944"/>
         <obo:IAO_0000115>A macrocyclic lactone with a ring of twelve or more members derived from a polyketide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>macrolide</rdfs:label>
     </owl:Class>
     
@@ -1796,11 +1786,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25362 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25362">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25367"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33259"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25367"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33259"/>
         <obo:IAO_0000115>A molecule all atoms of which have the same atomic number.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>elemental molecule</rdfs:label>
     </owl:Class>
     
@@ -1808,10 +1798,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25367 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25367">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36357"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
         <obo:IAO_0000115>Any polyatomic entity that is an electrically neutral entity consisting of more than one atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>molecule</rdfs:label>
     </owl:Class>
     
@@ -1819,10 +1809,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25384 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25384">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25384">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
         <obo:IAO_0000115>An oxoacid containing a single carboxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monocarboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -1830,10 +1820,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25389 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25389">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24676"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25389">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24676"/>
         <obo:IAO_0000115>Any hydroxybenzoic acid having a single phenolic hydroxy substituent on the benzene ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monohydroxybenzoic acid</rdfs:label>
     </owl:Class>
     
@@ -1841,11 +1831,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25477 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25477">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33836"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36785"/>
-        <obo:IAO_0000115>Any benzenoid aromatic compound having a skeleton composed of two ortho-fused benzene rings.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25477">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33836"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36785"/>
+        <obo:IAO_0000115>Any benzenoid aromatic compound having a skeleton composed of two &lt;em&gt;ortho&lt;/em&gt;-fused benzene rings.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>naphthalenes</rdfs:label>
     </owl:Class>
     
@@ -1853,11 +1843,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25529 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25529">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26421"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>A member of the class of pyridines that is a substituted pyridine in which at least one of the substituents is a carboxamide or N-substituted caraboxamide group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25529">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26421"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>A member of the class of pyridines that is a substituted pyridine in which at least one of the substituents is a carboxamide or &lt;em&gt;N&lt;/em&gt;-substituted caraboxamide group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyridinecarboxamide</rdfs:label>
     </owl:Class>
     
@@ -1865,10 +1855,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25558 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25558">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24531"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25558">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24531"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organonitrogen heterocyclic antibiotic</rdfs:label>
     </owl:Class>
     
@@ -1876,9 +1866,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25585 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25585">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33250"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25585">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nonmetal atom</rdfs:label>
     </owl:Class>
     
@@ -1886,9 +1876,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25661 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25661">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25661">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oleandomycins</rdfs:label>
     </owl:Class>
     
@@ -1896,10 +1886,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25693 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25693">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33670"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25693">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33670"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heteromonocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -1907,11 +1897,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25696 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25696">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22563"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25699"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25696">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22563"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25699"/>
         <obo:IAO_0000115>Any organic ion with a net negative charge.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic anion</rdfs:label>
     </owl:Class>
     
@@ -1919,10 +1909,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25698 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25698">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25698">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
         <obo:IAO_0000115>An organooxygen compound with formula ROR, where R is not hydrogen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ether</rdfs:label>
     </owl:Class>
     
@@ -1930,10 +1920,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25699 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25699">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24870"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25699">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24870"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic ion</rdfs:label>
     </owl:Class>
     
@@ -1941,10 +1931,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25703 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25703">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25710"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26020"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25703">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25710"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26079"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic phosphate</rdfs:label>
     </owl:Class>
     
@@ -1952,11 +1943,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25710 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25710">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26082"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25710">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26082"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
         <obo:IAO_0000115>An organophosphorus compound is formally a compound containing at least one carbon-phosphorus bond, but the term is often extended to include esters and thioesters.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organophosphorus compound</rdfs:label>
     </owl:Class>
     
@@ -1964,11 +1955,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25741 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25741">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25806"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25741">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
         <obo:IAO_0000115>An oxide is a chemical compound of oxygen with other chemical elements.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxide</rdfs:label>
     </owl:Class>
     
@@ -1976,11 +1967,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25750 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25750">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000115>Compounds of structure R2C=NOH derived from condensation of aldehydes or ketones with hydroxylamine. Oximes from aldehydes may be called aldoximes; those from ketones may be called ketoximes.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25750">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000115>Compounds of structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C=NOH derived from condensation of aldehydes or ketones with hydroxylamine. Oximes from aldehydes may be called aldoximes; those from ketones may be called ketoximes.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxime</rdfs:label>
     </owl:Class>
     
@@ -1988,10 +1979,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25754 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25754">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25754">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
         <obo:IAO_0000115>Any compound that has an aldehydic or ketonic group as well as a carboxylic acid group in the same molecule.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxo carboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -1999,9 +1990,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25806 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25806">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33304"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25806">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33304"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxygen molecular entity</rdfs:label>
     </owl:Class>
     
@@ -2009,9 +2000,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25807 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25807">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24531"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25807">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24531"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organooxygen heterocyclic antibiotic</rdfs:label>
     </owl:Class>
     
@@ -2019,10 +2010,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25865 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25865">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35992"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25865">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35992"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>penicillanic acids</rdfs:label>
     </owl:Class>
     
@@ -2030,10 +2021,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_25903 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_25903">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25903">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
         <obo:IAO_0000115>A chemically diverse class of peptides that exhibit antimicrobial properties.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>peptide antibiotic</rdfs:label>
     </owl:Class>
     
@@ -2041,10 +2032,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26004 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26004">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
         <obo:IAO_0000115>Any organic aromatic compound with a structure based on a phenylpropane skeleton. The class includes naturally occurring phenylpropanoid esters, flavonoids, anthocyanins, coumarins and many small phenolic molecules as well as their semi-synthetic and synthetic analogues. Phenylpropanoids are also precursors of lignin.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phenylpropanoid</rdfs:label>
     </owl:Class>
     
@@ -2052,10 +2043,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26020 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26020">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26079"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26079"/>
         <obo:IAO_0000115>Salts and esters of phosphoric and oligophosphoric acids and their chalcogen analogues. In inorganic chemistry, the term is also used to describe anionic coordination entities with phosphorus as central atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphate</rdfs:label>
     </owl:Class>
     
@@ -2063,10 +2054,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26069 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26069">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36360"/>
-        <obo:IAO_0000115>HP(=O)(OH)2  (phosphonic acid) and its P-substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26069">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36360"/>
+        <obo:IAO_0000115>HP(=O)(OH)&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;  (phosphonic acid) and its P-substituted derivatives.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphonic acids</rdfs:label>
     </owl:Class>
     
@@ -2074,9 +2065,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26079 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26079">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36359"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26079">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36359"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphoric acid derivative</rdfs:label>
     </owl:Class>
     
@@ -2084,9 +2075,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26082 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26082">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33302"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26082">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphorus molecular entity</rdfs:label>
     </owl:Class>
     
@@ -2094,10 +2085,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26144 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26144">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>piperazines</rdfs:label>
     </owl:Class>
     
@@ -2105,10 +2096,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26151 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26151">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26151">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>piperidines</rdfs:label>
     </owl:Class>
     
@@ -2116,10 +2107,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26188 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26188">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>Natural and synthetic compounds containing alternating carbonyl and methylene groups (&apos;beta-polyketones&apos;), biogenetically derived from repeated condensation of acetyl coenzyme A (via malonyl coenzyme A), and usually the compounds derived from them by further condensations, etc. Considered by many to be synonymous with the less frequently used terms acetogenins and ketides.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26188">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>Natural and synthetic compounds containing alternating carbonyl and methylene groups (&apos;β-polyketones&apos;), biogenetically derived from repeated condensation of acetyl coenzyme A (via malonyl coenzyme A), and usually the compounds derived from them by further condensations, etc. Considered by many to be synonymous with the less frequently used terms acetogenins and ketides.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyketide</rdfs:label>
     </owl:Class>
     
@@ -2127,10 +2118,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26191 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26191">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33822"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26191">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33822"/>
         <obo:IAO_0000115>A compound that contains two or more hydroxy groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyol</rdfs:label>
     </owl:Class>
     
@@ -2138,10 +2129,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26195 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26195">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26195">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
         <obo:IAO_0000115>Members of the class of phenols that contain 2 or more benzene rings each of which is substituted by at least one hydroxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyphenol</rdfs:label>
     </owl:Class>
     
@@ -2149,10 +2140,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26273 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26273">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83821"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83821"/>
         <obo:IAO_0000115>An amino acid derivative resulting from reaction of proline at the amino group or the carboxy group, or from the replacement of any hydrogen of proline by a heteroatom. The definition normally excludes peptides containing proline residues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>proline derivative</rdfs:label>
     </owl:Class>
     
@@ -2160,13 +2151,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_2637 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_2637">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22390"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47779"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2637">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22390"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47779"/>
         <obo:IAO_0000115>An amino cyclitol glycoside that is kanamycin A acylated at the N-1 position by a 4-amino-2-hydroxybutyryl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>amikacin</rdfs:label>
     </owl:Class>
     
@@ -2174,10 +2165,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26394 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26394">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26401"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33838"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26394">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26401"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33838"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>purine nucleoside</rdfs:label>
     </owl:Class>
     
@@ -2185,11 +2176,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26399 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26399">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_18254"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26394"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26399">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18254"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26394"/>
         <obo:IAO_0000115>A ribonucleoside that has a purine moiety as the nucleobase (the R group in the illustration).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>purine ribonucleoside</rdfs:label>
     </owl:Class>
     
@@ -2197,10 +2188,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26401 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26401">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35875"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26401">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35875"/>
         <obo:IAO_0000115>A class of imidazopyrimidines that consists of purine and its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13678</oboInOwl:hasAlternativeId>
         <rdfs:label>purines</rdfs:label>
     </owl:Class>
@@ -2209,9 +2200,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26404 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26404">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22260"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26404">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22260"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>puromycins</rdfs:label>
     </owl:Class>
     
@@ -2219,10 +2210,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26416 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26416">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22315"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26421"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22315"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26421"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyridine alkaloid</rdfs:label>
     </owl:Class>
     
@@ -2230,11 +2221,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26421 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26421">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any organonitrogen heterocyclic compound based on a pyridine skeleton and its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyridines</rdfs:label>
     </owl:Class>
     
@@ -2242,10 +2233,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26455 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26455">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26455">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole that includes only one N atom and no other heteroatom as a part of the aromatic skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyrroles</rdfs:label>
     </owl:Class>
     
@@ -2253,10 +2244,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26469 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26469">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26469">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
         <obo:IAO_0000115>A nitrogen molecular entity that is electronically neutral but which contains a quaternary nitrogen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>quaternary nitrogen compound</rdfs:label>
     </owl:Class>
     
@@ -2264,11 +2255,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26512 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26512">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33859"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26512">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33859"/>
         <obo:IAO_0000115>Any aromatic carboxylic acid that contains a quinoline moiety that is substituted by one carboxy substituent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>quinolinemonocarboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -2276,11 +2267,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26513 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26513">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000115>A class of aromatic heterocyclic compounds each of which contains a benzene ring ortho fused to carbons 2 and 3 of a pyridine ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26513">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000115>A class of aromatic heterocyclic compounds each of which contains a benzene ring &lt;em&gt;ortho&lt;/em&gt; fused to carbons 2 and 3 of a pyridine ring.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>quinolines</rdfs:label>
     </owl:Class>
     
@@ -2288,10 +2279,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26580 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26580">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22565"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39270"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26580">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22565"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39270"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>rifamycins</rdfs:label>
     </owl:Class>
     
@@ -2299,10 +2290,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26649 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26649">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83821"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26649">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83821"/>
         <obo:IAO_0000115>An amino acid derivative resulting from reaction of serine at the amino group or the carboxy group, or from the replacement of any hydrogen of serine by a heteroatom. The definition normally excludes peptides containing serine residues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>serine derivative</rdfs:label>
     </owl:Class>
     
@@ -2310,10 +2301,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_267413 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_267413">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25389"/>
-        <obo:IAO_0000115>A monohydroxybenzoic acid consisting of 5-aminosalicylic acid (mesalazine) linked to 4-aminobenzoyl-beta-alanine via an azo bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_267413">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25389"/>
+        <obo:IAO_0000115>A monohydroxybenzoic acid consisting of 5-aminosalicylic acid (mesalazine) linked to 4-aminobenzoyl-β-alanine &lt;em&gt;via&lt;/em&gt; an azo bond.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>balsalazide</rdfs:label>
     </owl:Class>
     
@@ -2321,10 +2312,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_2676 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_2676">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2676">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a 2-amino-2-(4-hydroxyphenyl)acetamido group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:133770</oboInOwl:hasAlternativeId>
         <rdfs:label>amoxicillin</rdfs:label>
     </owl:Class>
@@ -2333,10 +2325,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26761 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26761">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35341"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_49319"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26761">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_49319"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>steroid antibiotic</rdfs:label>
     </owl:Class>
     
@@ -2344,10 +2336,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26788 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26788">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26788">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>streptomycins</rdfs:label>
     </owl:Class>
     
@@ -2355,10 +2347,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26822 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26822">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26835"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26822">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26835"/>
         <obo:IAO_0000115>Any sulfur molecular entity that involves either covalently bonded or anionic sulfur.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfide</rdfs:label>
     </owl:Class>
     
@@ -2366,9 +2358,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26835 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26835">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33304"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26835">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33304"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfur molecular entity</rdfs:label>
     </owl:Class>
     
@@ -2376,10 +2368,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26878 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26878">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <obo:IAO_0000115>A tertiary alcohol is a compound in which a hydroxy group, -OH, is attached to a saturated carbon atom which has three other carbon atoms attached to it.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26878">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+        <obo:IAO_0000115>A tertiary alcohol is a compound in which a hydroxy group, ‒OH, is attached to a saturated carbon atom which has three other carbon atoms attached to it.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tertiary alcohol</rdfs:label>
     </owl:Class>
     
@@ -2387,10 +2379,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26895 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26895">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26188"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26895">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26188"/>
         <obo:IAO_0000115>A subclass of polyketides having an octahydrotetracene-2-carboxamide skeleton, substituted with many hydroxy and other groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tetracyclines</rdfs:label>
     </owl:Class>
     
@@ -2398,11 +2390,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26912 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26912">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26912">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Any oxacycle having an oxolane (tetrahydrofuran) skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxolanes</rdfs:label>
     </owl:Class>
     
@@ -2410,10 +2402,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26961 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26961">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38106"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26961">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38106"/>
         <obo:IAO_0000115>Compounds containing at least one thiophene ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiophenes</rdfs:label>
     </owl:Class>
     
@@ -2421,12 +2413,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_26979 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_26979">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36688"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51959"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26979">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36688"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51959"/>
         <obo:IAO_0000115>An organic tricyclic compound in which at least one of the rings of the tricyclic skeleton contains one or more heteroatoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heterotricyclic compound</rdfs:label>
     </owl:Class>
     
@@ -2434,10 +2426,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27136 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27136">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26191"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27136">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26191"/>
         <obo:IAO_0000115>A chemical compound containing three hydroxy groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>triol</rdfs:label>
     </owl:Class>
     
@@ -2445,10 +2437,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27171 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27171">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33672"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27171">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33672"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heterobicyclic compound</rdfs:label>
     </owl:Class>
     
@@ -2456,10 +2448,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27369 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27369">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51151"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27369">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51151"/>
         <obo:IAO_0000115>A neutral compound having formal unit electrical charges of opposite sign on non-adjacent atoms. Sometimes referred to as inner salts, dipolar ions (a misnomer).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>zwitterion</rdfs:label>
     </owl:Class>
     
@@ -2467,11 +2459,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27565 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27565">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22495"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27565">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22495"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
         <obo:IAO_0000115>An aminobenzoic acid that is salicylic acid substituted by an amino group at position 4.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:1789</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:20320</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41152</oboInOwl:hasAlternativeId>
@@ -2482,14 +2474,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27644 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27644">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_139592"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26895"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83403"/>
-        <obo:IAO_0000115>A member of the class of tetracyclines with formula C22H23ClN2O8 isolated from Streptomyces aureofaciens.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27644">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_139592"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26878"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26895"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83403"/>
+        <obo:IAO_0000115>A member of the class of tetracyclines with formula C&lt;small&gt;&lt;sub&gt;22&lt;/sub&gt;&lt;/small&gt;H&lt;small&gt;&lt;sub&gt;23&lt;/sub&gt;&lt;/small&gt;ClN&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;O&lt;small&gt;&lt;sub&gt;8&lt;/sub&gt;&lt;/small&gt; isolated from &lt;em&gt;Streptomyces aureofaciens&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:23164</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3653</oboInOwl:hasAlternativeId>
         <rdfs:label>chlortetracycline</rdfs:label>
@@ -2499,9 +2492,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27666 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27666">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_15369"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27666">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15369"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22218</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2446</oboInOwl:hasAlternativeId>
         <rdfs:label>actinomycin D</rdfs:label>
@@ -2511,12 +2504,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_2790 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_2790">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47779"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_61800"/>
-        <obo:IAO_0000115>An aminoglycoside that is 2-deoxystreptamine that is substituted on the oxygen at position 4 by an (8R)-2-amino-8-O-(4-amino-4-deoxy-alpha-D-glucopyranosyl)-2,3,7-trideoxy-7-(methylamino)-D-glycero-alpha-D-allo-octodialdo-1,5:8,4-dipyranos-1-yl) group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2790">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47779"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_61800"/>
+        <obo:IAO_0000115>An aminoglycoside that is 2-deoxystreptamine that is substituted on the oxygen at position 4 by an (8&lt;i&gt;R&lt;/i&gt;)-2-amino-8-&lt;em&gt;O&lt;/em&gt;-(4-amino-4-deoxy-α-&lt;small&gt;D&lt;/small&gt;-glucopyranosyl)-2,3,7-trideoxy-7-(methylamino)-&lt;small&gt;D&lt;/small&gt;-glycero-α-&lt;small&gt;D&lt;/small&gt;-&lt;i&gt;allo&lt;/i&gt;-octodialdo-1,5:8,4-dipyranos-1-yl) group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:40708</oboInOwl:hasAlternativeId>
         <rdfs:label>apramycin</rdfs:label>
     </owl:Class>
@@ -2525,11 +2518,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_27933 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_27933">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25558"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35627"/>
-        <obo:IAO_0000115>An organonitrogen heterocyclic antibiotic that contains a beta-lactam ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27933">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35627"/>
+        <obo:IAO_0000115>An organonitrogen heterocyclic antibiotic that contains a β-lactam ring.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:10427</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22844</oboInOwl:hasAlternativeId>
         <rdfs:label>beta-lactam antibiotic</rdfs:label>
@@ -2539,10 +2532,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28001 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28001">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <obo:IAO_0000115>A complex glycopeptide from Streptomyces orientalis. It inhibits a specific step in the synthesis of the peptidoglycan layer in the Gram-positive bacteria Staphylococcus aureus and Clostridium difficile.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <obo:IAO_0000115>A complex glycopeptide from &lt;em&gt;Streptomyces orientalis&lt;/em&gt;. It inhibits a specific step in the synthesis of the peptidoglycan layer in the Gram-positive bacteria &lt;em&gt;Staphylococcus aureus&lt;/em&gt; and &lt;em&gt;Clostridium difficile&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:27276</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:49941</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9931</oboInOwl:hasAlternativeId>
@@ -2553,15 +2546,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28077 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28077">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26580"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46847"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46920"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59779"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <obo:IAO_0000115>A member of the class of rifamycins that is a a semisynthetic antibiotic derived from Amycolatopsis rifamycinica (previously known as Amycolatopsis mediterranei and Streptomyces mediterranei).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28077">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26580"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46847"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46920"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59779"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <obo:IAO_0000115>A member of the class of rifamycins that is a a semisynthetic antibiotic derived from &lt;em&gt;Amycolatopsis rifamycinica&lt;/em&gt; (previously known as &lt;em&gt;Amycolatopsis mediterranei&lt;/em&gt; and &lt;em&gt;Streptomyces mediterranei&lt;/em&gt;).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26577</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:45308</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8858</oboInOwl:hasAlternativeId>
@@ -2572,10 +2565,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_281056 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_281056">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55504"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_281056">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55504"/>
         <obo:IAO_0000115>The conjugate base of loracarbef.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>loracarbef anion</rdfs:label>
     </owl:Class>
     
@@ -2583,16 +2576,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28368 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28368">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23003"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25698"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35313"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37912"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63367"/>
-        <obo:IAO_0000115>A coumarin-derived antibiotic obtained from Streptomyces niveus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28368">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25698"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35313"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37912"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63367"/>
+        <obo:IAO_0000115>A coumarin-derived antibiotic obtained from &lt;em&gt;Streptomyces niveus&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25597</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44505</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7644</oboInOwl:hasAlternativeId>
@@ -2603,10 +2596,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28659 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28659">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25585"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33300"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28659">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25585"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33300"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26080</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8168</oboInOwl:hasAlternativeId>
         <rdfs:label>phosphorus atom</rdfs:label>
@@ -2616,10 +2609,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28864 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28864">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28864">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
         <obo:IAO_0000115>A amino cyclitol glycoside that is kanamycin B lacking the 3-hydroxy substituent from the 2,6-diaminoglucose ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:19849</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:45933</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9610</oboInOwl:hasAlternativeId>
@@ -2630,10 +2623,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28908 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28908">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24397"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28908">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24397"/>
         <obo:IAO_0000115>A glycophospholipid antibiotic compound with the lipid portion conjugated to a pentasaccharide fraction via a phosphate linkage.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25360</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:5075</oboInOwl:hasAlternativeId>
         <rdfs:label>bambermycin</rdfs:label>
@@ -2643,11 +2636,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28915 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28915">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26069"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32955"/>
-        <obo:IAO_0000115>A phosphonic acid having an (R,S)-1,2-epoxypropyl group attached to phosphorus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28915">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26069"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32955"/>
+        <obo:IAO_0000115>A phosphonic acid having an (&lt;i&gt;R&lt;/i&gt;,&lt;i&gt;S&lt;/i&gt;)-1,2-epoxypropyl group attached to phosphorus.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24100</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:42503</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8159</oboInOwl:hasAlternativeId>
@@ -2658,10 +2651,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28963 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28963">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28963">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>Any sugar having one or more alcoholic hydroxy groups replaced by substituted or unsubstituted amino groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22481</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22530</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2662</oboInOwl:hasAlternativeId>
@@ -2672,10 +2665,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_28971 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_28971">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28971">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a 2-amino-2-phenylacetamido group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22536</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2683</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:40648</oboInOwl:hasAlternativeId>
@@ -2687,13 +2682,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29007 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29007">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36816"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38418"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39410"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36816"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38418"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39410"/>
         <obo:IAO_0000115>A third-generation cephalosporin compound having 2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetylamino and [(2-methyl-5,6-dioxo-1,2,5,6-tetrahydro-1,2,4-triazin-3-yl)sulfanyl]methyl side-groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:23059</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3513</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:446214</oboInOwl:hasAlternativeId>
@@ -2704,15 +2699,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29013 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29013">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_19129"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26761"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35915"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36835"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47891"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_79020"/>
-        <obo:IAO_0000115>A steroid antibiotic that is isolated from the fermentation broth of Fusidium coccineum.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_19129"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26761"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35915"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36835"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47891"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_79020"/>
+        <obo:IAO_0000115>A steroid antibiotic that is isolated from the fermentation broth of &lt;em&gt;Fusidium coccineum&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24133</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:42742</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:5201</oboInOwl:hasAlternativeId>
@@ -2723,11 +2718,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29067 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29067">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25696"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35406"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29067">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25696"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35406"/>
         <obo:IAO_0000115>The conjugate base formed when the carboxy group of a carboxylic acid is deprotonated.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13626</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13945</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23026</oboInOwl:hasAlternativeId>
@@ -2739,10 +2734,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29347 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29347">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29347">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
         <obo:IAO_0000115>A carboxamide derived from a monocarboxylic acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13211</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22207</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25383</oboInOwl:hasAlternativeId>
@@ -2754,10 +2749,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_2955 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_2955">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2955">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
         <obo:IAO_0000115>A macrolide antibiotic useful for the treatment of bacterial infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:46596</oboInOwl:hasAlternativeId>
         <rdfs:label>azithromycin</rdfs:label>
     </owl:Class>
@@ -2766,11 +2761,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29556 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29556">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63353"/>
-        <obo:IAO_0000115>A complex glycopeptide antibiotic that is isolated from Amycolatopsis orientalis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29556">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63353"/>
+        <obo:IAO_0000115>A complex glycopeptide antibiotic that is isolated from &lt;em&gt;Amycolatopsis orientalis&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chloroeremomycin</rdfs:label>
     </owl:Class>
     
@@ -2778,11 +2773,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_2956 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_2956">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
-        <obo:IAO_0000115>A semisynthetic penicillin having a 6beta-{(2R)-2-[(2-oxoimidazolidine-1-carbonyl)amino]-2-phenylacetyl}amino side-group. It is an antibiotic used in treating infections caused by Pseudomonas aeruginosa, Escherichia coli and Haemophilus influenzae.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2956">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
+        <obo:IAO_0000115>A semisynthetic penicillin having a 6β-{(2&lt;i&gt;R&lt;/i&gt;)-2-[(2-oxoimidazolidine-1-carbonyl)amino]-2-phenylacetyl}amino side-group. It is an antibiotic used in treating infections caused by &lt;em&gt;Pseudomonas aeruginosa, Escherichia coli&lt;/em&gt; and &lt;em&gt;Haemophilus influenzae&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:63225</oboInOwl:hasAlternativeId>
         <rdfs:label>azlocillin</rdfs:label>
     </owl:Class>
@@ -2791,10 +2787,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29584 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29584">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24995"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_52898"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29584">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_52898"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:42746</oboInOwl:hasAlternativeId>
         <rdfs:label>GE2270A</rdfs:label>
     </owl:Class>
@@ -2803,12 +2799,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29630 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29630">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51689"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63367"/>
-        <obo:IAO_0000115>A twelve-membered macrolide antibiotic that is biosynthesised by Streptomyces venezuelae.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29630">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63367"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>methymycin</rdfs:label>
     </owl:Class>
     
@@ -2816,12 +2811,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29649 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29649">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51689"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63367"/>
-        <obo:IAO_0000115>A macrolide antibiotic that is narbonolide having a 3,4,6-trideoxy-3-(dimethylamino)-beta-D-xylo-hexopyranosyl residue attached at position 6. It is biosynthesised by Streptomyces venezuelae.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29649">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63367"/>
+        <obo:IAO_0000115>A macrolide antibiotic that is narbonolide having a 3,4,6-trideoxy-3-(dimethylamino)-β-&lt;small&gt;D&lt;/small&gt;-&lt;i&gt;xylo&lt;/i&gt;-hexopyranosyl residue attached at position 6. It is biosynthesised by &lt;em&gt;Streptomyces venezuelae&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:44624</oboInOwl:hasAlternativeId>
         <rdfs:label>narbomycin</rdfs:label>
     </owl:Class>
@@ -2830,12 +2825,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29665 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29665">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51689"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63367"/>
-        <obo:IAO_0000115>A macrolide antibiotic that is biosynthesised by Streptomyces venezuelae.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29665">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63367"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pikromycin</rdfs:label>
     </owl:Class>
     
@@ -2843,9 +2837,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29668 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29668">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29668">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Pulvomycin</rdfs:label>
     </owl:Class>
     
@@ -2853,14 +2847,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29673 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29673">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26195"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26580"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38163"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59779"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29673">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26195"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26580"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38163"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59779"/>
         <obo:IAO_0000115>A member of the class of rifamycins that exhibits antibiotic and antitubercular properties.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>rifamycin SV</rdfs:label>
     </owl:Class>
     
@@ -2868,9 +2864,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29688 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29688">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_28963"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29688">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_28963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:46029</oboInOwl:hasAlternativeId>
         <rdfs:label>telithromycin</rdfs:label>
     </owl:Class>
@@ -2879,10 +2875,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29693 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29693">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24533"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29693">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24533"/>
         <obo:IAO_0000115>A heterodetic cyclic peptide, in which the cyclisation step involves a formal lactonisation between the carboxy group of a quinaldic acid-based residue and a secondary alcohol. An antibiotic that inhibits bacterial protein synthesis. Also acts as an antitumor agent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiostrepton</rdfs:label>
     </owl:Class>
     
@@ -2890,11 +2886,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_29705 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_29705">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38032"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_3992"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29705">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38032"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_3992"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Valnemulin</rdfs:label>
     </owl:Class>
     
@@ -2902,10 +2898,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_30879 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_30879">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33822"/>
-        <obo:IAO_0000115>A compound in which a hydroxy group, -OH, is attached to a saturated carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_30879">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33822"/>
+        <obo:IAO_0000115>A compound in which a hydroxy group, ‒OH, is attached to a saturated carbon atom.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13804</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22288</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2553</oboInOwl:hasAlternativeId>
@@ -2916,9 +2912,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3139 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3139">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22907"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3139">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22907"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:165316</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:357107</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:41102</oboInOwl:hasAlternativeId>
@@ -2930,10 +2926,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_31577 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_31577">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_31577">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>Any organic amino compound that is a derivative of  ethylenediamine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ethylenediamine derivative</rdfs:label>
     </owl:Class>
     
@@ -2941,16 +2937,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_31739 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_31739">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17478"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26878"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63353"/>
-        <obo:IAO_0000115>A macrolide antibiotic produced by certain strains of Streptomyces narbonensis var. josamyceticus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_31739">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26878"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63353"/>
+        <obo:IAO_0000115>A macrolide antibiotic produced by certain strains of &lt;em&gt;Streptomyces narbonensis&lt;/em&gt; var. &lt;em&gt;josamyceticus&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>josamycin</rdfs:label>
     </owl:Class>
     
@@ -2958,11 +2954,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_31753 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_31753">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25022"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <obo:IAO_0000115>A macrolide antibiotic produced by Streptomyces kitasatoensis, showing activity against a wide spectrum of pathogens.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_31753">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25022"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <obo:IAO_0000115>A macrolide antibiotic produced by &lt;em&gt;Streptomyces kitasatoensis&lt;/em&gt;, showing activity against a wide spectrum of pathogens.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>leucomycin V</rdfs:label>
     </owl:Class>
     
@@ -2970,14 +2966,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_31810 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_31810">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38582"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46845"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_31810">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46845"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A fluoroquinolone antibiotic that is 4-oxo-1,4-dihydroquinoline which is substituted at positions 1, 3, 6, 7 and 8 by 2-fluoroethyl, carboxy, fluoro, 4-methylpiperazin-1-yl and fluoro groups, respectively. It is active against many Gram-positive and Gram-negative bacteria.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>fleroxacin</rdfs:label>
     </owl:Class>
     
@@ -2985,9 +2981,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_32066 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_32066">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26421"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32066">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26421"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:93717</oboInOwl:hasAlternativeId>
         <rdfs:label>Prothionamide</rdfs:label>
     </owl:Class>
@@ -2996,10 +2992,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_32215 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_32215">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35850"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35850"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiamphenicol</rdfs:label>
     </owl:Class>
     
@@ -3007,10 +3003,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_32583 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_32583">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35156"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35505"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32583">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35156"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35505"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>calcium sulfate dihydrate</rdfs:label>
     </owl:Class>
     
@@ -3018,10 +3014,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_32955 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_32955">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37407"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32955">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37407"/>
         <obo:IAO_0000115>Any cyclic ether in which the oxygen atom forms part of a 3-membered ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13828</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23930</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:4812</oboInOwl:hasAlternativeId>
@@ -3032,10 +3028,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_32988 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_32988">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000115>An amide is a derivative of an oxoacid RkE(=O)l(OH)m (l =/= 0) in which an acidic hydroxy group has been replaced by an amino or substituted amino group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32988">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000115>An amide is a derivative of an oxoacid R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH)&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt; (&lt;em&gt;l&lt;/em&gt; ≠ 0) in which an acidic hydroxy group has been replaced by an amino or substituted amino group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22473</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2633</oboInOwl:hasAlternativeId>
         <rdfs:label>amide</rdfs:label>
@@ -3045,9 +3041,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33241 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33241">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxoacid derivative</rdfs:label>
     </owl:Class>
     
@@ -3055,11 +3051,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33245 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33245">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37175"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33245">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37175"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>An organic fundamental parent is a structure used as a basis for substitutive names in organic nomenclature, containing, in addition to one or more hydrogen atoms, a single atom of an element, a number of atoms (alike or different) linked together to form an unbranched chain, a monocyclic or polycyclic ring system, or a ring assembly or ring/chain system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic fundamental parent</rdfs:label>
     </owl:Class>
     
@@ -3067,10 +3063,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33250 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33250">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24431"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33250">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
         <obo:IAO_0000115>A chemical entity constituting the smallest component of an element having the chemical properties of the element.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22671</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23907</oboInOwl:hasAlternativeId>
         <rdfs:label>atom</rdfs:label>
@@ -3080,10 +3076,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33256 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33256">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32988"/>
-        <obo:IAO_0000115>A derivative of an oxoacid RkE(=O)l(OH)m (l =/= 0) in which an acidic hydroxy group has been replaced by an amino or substituted amino group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33256">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32988"/>
+        <obo:IAO_0000115>A derivative of an oxoacid R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH)&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt; (&lt;em&gt;l&lt;/em&gt; ≠ 0) in which an acidic hydroxy group has been replaced by an amino or substituted amino group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>primary amide</rdfs:label>
     </owl:Class>
     
@@ -3091,10 +3087,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33257 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33257">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32988"/>
-        <obo:IAO_0000115>A derivative of two oxoacids RkE(=O)l(OH)m (l =/= 0) in which two acyl groups are attached to the amino or substituted amino group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33257">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32988"/>
+        <obo:IAO_0000115>A derivative of two oxoacids R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH)&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt; (&lt;em&gt;l&lt;/em&gt; ≠ 0) in which two acyl groups are attached to the amino or substituted amino group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>secondary amide</rdfs:label>
     </owl:Class>
     
@@ -3102,10 +3098,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33259 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33259">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>A molecular entity all atoms of which have the same atomic number.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>elemental molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3113,11 +3109,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33261 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33261">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26835"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36962"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33261">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26835"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36962"/>
         <obo:IAO_0000115>An organosulfur compound is a compound containing at least one carbon-sulfur bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:23010</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25714</oboInOwl:hasAlternativeId>
         <rdfs:label>organosulfur compound</rdfs:label>
@@ -3127,11 +3123,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33262 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33262">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24835"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25806"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33259"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33262">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24835"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33259"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>elemental oxygen</rdfs:label>
     </owl:Class>
     
@@ -3139,9 +3135,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33263 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33263">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33262"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33263">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33262"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diatomic oxygen</rdfs:label>
     </owl:Class>
     
@@ -3149,11 +3145,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33273 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33273">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22563"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36358"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22563"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36358"/>
         <obo:IAO_0000115>An anion consisting of more than one atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyatomic anion</rdfs:label>
     </owl:Class>
     
@@ -3161,10 +3157,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33281 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33281">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24432"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33281">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24432"/>
         <obo:IAO_0000115>A substance that kills or slows the growth of microorganisms, including bacteria, viruses, fungi and protozoans.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22582</oboInOwl:hasAlternativeId>
         <rdfs:label>antimicrobial agent</rdfs:label>
     </owl:Class>
@@ -3173,10 +3169,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33285 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33285">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33285">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>A heteroorganic entity is an organic molecular entity in which carbon atoms or organic groups are bonded directly to one or more heteroatoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteroorganic entity</rdfs:label>
     </owl:Class>
     
@@ -3184,10 +3180,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33290 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33290">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_52211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33290">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_52211"/>
         <obo:IAO_0000115>A physiological role played by any substance of either plant, animal or artificial origin which contains essential body nutrients that can be ingested by an organism to provide energy, promote growth, and maintain the processes of life.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>food</rdfs:label>
     </owl:Class>
     
@@ -3195,10 +3191,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33299 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33299">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33674"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33299">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33674"/>
         <obo:IAO_0000115>An alkaline earth molecular entity is a molecular entity containing one or more atoms of an alkaline earth metal.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alkaline earth molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3206,10 +3202,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33300 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33300">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33560"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33300">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33560"/>
         <obo:IAO_0000115>Any p-block element atom that is in group 15 of the periodic table: nitrogen, phosphorus, arsenic, antimony and bismuth.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pnictogen</rdfs:label>
     </owl:Class>
     
@@ -3217,10 +3213,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33302 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33302">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33675"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33302">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33675"/>
         <obo:IAO_0000115>A p-block molecular entity containing any pnictogen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pnictogen molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3228,10 +3224,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33304 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33304">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33675"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33304">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33675"/>
         <obo:IAO_0000115>Any p-block molecular entity containing a chalcogen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chalcogen molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3239,11 +3235,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33308 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33308">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35701"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36586"/>
-        <obo:IAO_0000115>An ester of a carboxylic acid, R(1)C(=O)OR(2), where R(1) = H or organyl and R(2) = organyl.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33308">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
+        <obo:IAO_0000115>An ester of a carboxylic acid, R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;C(=O)OR&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;, where R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt; = H or organyl and R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; = organyl.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13204</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23028</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3408</oboInOwl:hasAlternativeId>
@@ -3254,10 +3250,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33318 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33318">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33250"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33318">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
         <obo:IAO_0000115>An atom belonging to one of the main groups (found in the s- and p- blocks) of the periodic table.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>main group element atom</rdfs:label>
     </owl:Class>
     
@@ -3265,10 +3261,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33406 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33406">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_143084"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22632"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33406">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_143084"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22632"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organoarsenic compound</rdfs:label>
     </owl:Class>
     
@@ -3276,10 +3272,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33424 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33424">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26835"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33241"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33424">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26835"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33241"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfur oxoacid derivative</rdfs:label>
     </owl:Class>
     
@@ -3287,10 +3283,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33458 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33458">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33459"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33458">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33459"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nitrogen oxoanion</rdfs:label>
     </owl:Class>
     
@@ -3298,10 +3294,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33459 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33459">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33302"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35406"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33459">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33302"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35406"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pnictogen oxoanion</rdfs:label>
     </owl:Class>
     
@@ -3309,9 +3305,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33552 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33552">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33424"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33552">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33424"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfonic acid derivative</rdfs:label>
     </owl:Class>
     
@@ -3319,10 +3315,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33560 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33560">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33318"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33560">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33318"/>
         <obo:IAO_0000115>Any main group element atom belonging to the p-block of the periodic table.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>p-block element atom</rdfs:label>
     </owl:Class>
     
@@ -3330,10 +3326,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33563 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33563">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35740"/>
-        <obo:IAO_0000115>Any member of class of 1,2-di-O-acylglycerols joined at oxygen 3 by a glycosidic linkage to a carbohydrate part (usually a mono-, di- or tri-saccharide). Some substances classified as bacterial glycolipids have the sugar part acylated by one or more fatty acids and the glycerol part may be absent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33563">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35740"/>
+        <obo:IAO_0000115>Any member of class of 1,2-di-&lt;em&gt;O&lt;/em&gt;-acylglycerols joined at oxygen 3 by a glycosidic linkage to a carbohydrate part (usually a mono-, di- or tri-saccharide). Some substances classified as bacterial glycolipids have the sugar part acylated by one or more fatty acids and the glycerol part may be absent.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24393</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:5476</oboInOwl:hasAlternativeId>
         <rdfs:label>glycolipid</rdfs:label>
@@ -3343,12 +3339,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33575 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33575">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35605"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36586"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_64709"/>
-        <obo:IAO_0000115>A carbon oxoacid acid carrying at least one -C(=O)OH group and having the structure RC(=O)OH, where R is any any monovalent functional group. Carboxylic acids are the most common type of organic acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33575">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35605"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_64709"/>
+        <obo:IAO_0000115>A carbon oxoacid acid carrying at least one ‒C(=O)OH group and having the structure RC(=O)OH, where R is any any monovalent functional group. Carboxylic acids are the most common type of organic acid.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13428</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13627</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:23027</oboInOwl:hasAlternativeId>
@@ -3359,10 +3355,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33579 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33579">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33579">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>A molecular entity containing one or more atoms from any of groups 1, 2, 13, 14, 15, 16, 17, and 18 of the periodic table.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>main group molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3370,9 +3366,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33582 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33582">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33675"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33582">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33675"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbon group molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3380,10 +3376,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33595 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33595">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33595">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25367"/>
         <obo:IAO_0000115>Any molecule that consists of a series of atoms joined together to form a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3391,10 +3387,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33597 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33597">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33597">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
         <obo:IAO_0000115>A cyclic compound having as ring members atoms of the same element only.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>homocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3402,11 +3398,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33598 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33598">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33597"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33832"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33598">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33597"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33832"/>
         <obo:IAO_0000115>A homocyclic compound in which all of the ring members are carbon atoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3414,9 +3410,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33608 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33608">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33674"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33608">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33674"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrogen molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3424,9 +3420,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33635 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33635">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33635">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polycyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3434,10 +3430,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33636 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33636">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33636">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
         <obo:IAO_0000115>A molecule that features two fused rings.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>bicyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3445,10 +3441,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33655 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33655">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
-        <obo:IAO_0000115>A cyclically conjugated molecular entity with a stability (due to delocalization) significantly greater than that of a hypothetical localized structure (e.g. Kekule structure) is said to possess aromatic character.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33655">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
+        <obo:IAO_0000115>A cyclically conjugated molecular entity with a stability (due to delocalization) significantly greater than that of a hypothetical localized structure (e.g. Kekulé structure) is said to possess aromatic character.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aromatic compound</rdfs:label>
     </owl:Class>
     
@@ -3456,10 +3452,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33659 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33659">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33655"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33832"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33659">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33655"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33832"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic aromatic compound</rdfs:label>
     </owl:Class>
     
@@ -3467,9 +3463,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33661 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33661">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33661">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3477,10 +3473,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33670 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33670">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33661"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5686"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33670">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33661"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5686"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteromonocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3488,11 +3484,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33671 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33671">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33635"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5686"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33671">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33635"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5686"/>
         <obo:IAO_0000115>A polycyclic compound in which at least one of the rings contains at least one non-carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteropolycyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3500,11 +3496,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33672 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33672">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33636"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5686"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33672">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33636"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5686"/>
         <obo:IAO_0000115>A bicyclic compound in which at least one of the rings contains at least one skeletal heteroatom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterobicyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3512,10 +3508,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33674 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33674">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33579"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33674">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33579"/>
         <obo:IAO_0000115>An s-block molecular entity is a molecular entity containing one or more atoms of an s-block element.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>s-block molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3523,10 +3519,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33675 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33675">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33579"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33675">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33579"/>
         <obo:IAO_0000115>A main group molecular entity that contains one or more atoms of a p-block element.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>p-block molecular entity</rdfs:label>
     </owl:Class>
     
@@ -3534,11 +3530,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33692 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33692">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33608"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33608"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
         <obo:IAO_0000115>Hydrides are chemical compounds of hydrogen with other chemical elements.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrides</rdfs:label>
     </owl:Class>
     
@@ -3546,11 +3542,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33694 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33694">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33839"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33694">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33839"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>A macromolecule formed by a living organism.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>biomacromolecule</rdfs:label>
     </owl:Class>
     
@@ -3558,9 +3554,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33695 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33695">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33694"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33695">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33694"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>information biomacromolecule</rdfs:label>
     </owl:Class>
     
@@ -3568,10 +3564,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33696 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33696">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_15986"/>
-        <obo:IAO_0000115>A macromolecule made up of nucleotide units and hydrolysable into certain pyrimidine or purine bases (usually adenine, cytosine, guanine, thymine, uracil), D-ribose or 2-deoxy-D-ribose and phosphoric acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33696">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15986"/>
+        <obo:IAO_0000115>A macromolecule made up of nucleotide units and hydrolysable into certain pyrimidine or purine bases (usually adenine, cytosine, guanine, thymine, uracil), &lt;small&gt;D&lt;/small&gt;-ribose or 2-deoxy-&lt;small&gt;D&lt;/small&gt;-ribose and phosphoric acid.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nucleic acid</rdfs:label>
     </owl:Class>
     
@@ -3579,10 +3575,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33697 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33697">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33696"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33697">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33696"/>
         <obo:IAO_0000115>High molecular weight, linear polymers, composed of nucleotides containing ribose and linked by phosphodiester bonds; RNA is central to the synthesis of proteins.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ribonucleic acid</rdfs:label>
     </owl:Class>
     
@@ -3590,10 +3586,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33704 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33704">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33709"/>
-        <obo:IAO_0000115>An amino acid in which the amino group is located on the carbon atom at the position alpha to the carboxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33704">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33709"/>
+        <obo:IAO_0000115>An amino acid in which the amino group is located on the carbon atom at the position α to the carboxy group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:10208</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13779</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22442</oboInOwl:hasAlternativeId>
@@ -3605,11 +3601,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33709 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33709">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33709">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>A carboxylic acid containing one or more amino groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13815</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22477</oboInOwl:hasAlternativeId>
         <rdfs:label>amino acid</rdfs:label>
@@ -3619,9 +3615,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3371 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3371">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3371">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>capreomycin</rdfs:label>
     </owl:Class>
     
@@ -3629,11 +3625,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33822 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33822">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24651"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33822">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24651"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>An organic compound having at least one hydroxy group attached to a carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:64710</oboInOwl:hasAlternativeId>
         <rdfs:label>organic hydroxy compound</rdfs:label>
     </owl:Class>
@@ -3642,11 +3638,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33832 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33832">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72695"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33832">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72695"/>
         <obo:IAO_0000115>Any organic molecule that consists of atoms connected in the form of a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic cyclic compound</rdfs:label>
     </owl:Class>
     
@@ -3654,11 +3650,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33833 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33833">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <obo:IAO_0000115>A heterocyclic compound formally derived from an arene by replacement of one or more methine (-C=) and/or vinylene (-CH=CH-) groups by trivalent or divalent heteroatoms, respectively, in such a way as to maintain the continuous pi-electron system characteristic of aromatic systems and a number of out-of-plane pi-electrons corresponding to the Hueckel rule (4n+2).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33833">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <obo:IAO_0000115>A heterocyclic compound formally derived from an arene by replacement of one or more methine (‒C=) and/or vinylene (‒CH=CH‒) groups by trivalent or divalent heteroatoms, respectively, in such a way as to maintain the continuous π-electron system characteristic of aromatic systems and a number of out-of-plane π-electrons corresponding to the Hückel rule (4&lt;em&gt;n&lt;/em&gt;+2).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteroarene</rdfs:label>
     </owl:Class>
     
@@ -3666,10 +3662,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33836 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33836">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33598"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33836">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33598"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>benzenoid aromatic compound</rdfs:label>
     </owl:Class>
     
@@ -3677,12 +3673,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33838 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33838">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_21731"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26912"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_61120"/>
-        <obo:IAO_0000115>An N-glycosyl compound that has both a nucleobase, normally adenine, guanine, xanthine, thymine, cytosine or uracil, and either a ribose or deoxyribose as functional parents.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33838">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_21731"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26912"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_61120"/>
+        <obo:IAO_0000115>An &lt;em&gt;N&lt;/em&gt;-glycosyl compound that has both a nucleobase, normally adenine, guanine, xanthine, thymine, cytosine or uracil, and either a ribose or deoxyribose as functional parents.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13661</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25611</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7647</oboInOwl:hasAlternativeId>
@@ -3693,10 +3689,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33839 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33839">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36357"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33839">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
         <obo:IAO_0000115>A macromolecule is a molecule of high relative molecular mass, the structure of which essentially comprises the multiple repetition of units derived, actually or conceptually, from molecules of low relative molecular mass.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>macromolecule</rdfs:label>
     </owl:Class>
     
@@ -3704,15 +3700,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33853 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33853">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33822"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33853">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33822"/>
         <obo:IAO_0000115>Organic aromatic compounds having one or more hydroxy groups attached to a benzene or other arene ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13664</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13825</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25969</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2857</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:29322</oboInOwl:hasAlternativeId>
         <rdfs:label>phenols</rdfs:label>
     </owl:Class>
     
@@ -3720,11 +3717,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33856 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33856">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33709"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33856">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33709"/>
         <obo:IAO_0000115>An amino acid whose structure includes an aromatic ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13820</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22623</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2835</oboInOwl:hasAlternativeId>
@@ -3735,11 +3732,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33859 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33859">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33859">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
         <obo:IAO_0000115>Any carboxylic acid in which the carboxy group is directly bonded to an aromatic ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13817</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13821</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:2830</oboInOwl:hasAlternativeId>
@@ -3750,11 +3747,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33860 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33860">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33860">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>An amino compound in which the amino group is linked directly to an aromatic system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13827</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22622</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22646</oboInOwl:hasAlternativeId>
@@ -3767,10 +3764,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3393 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3393">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
-        <obo:IAO_0000115>A penicillin antibiotic having a 6beta-2-carboxy-2-phenylacetamido side-chain.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3393">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
+        <obo:IAO_0000115>A penicillin antibiotic having a 6β-2-carboxy-2-phenylacetamido side-chain.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbenicillin</rdfs:label>
     </owl:Class>
     
@@ -3778,10 +3776,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_33958 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33958">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24866"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37578"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33958">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24866"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37578"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>halide salt</rdfs:label>
     </owl:Class>
     
@@ -3789,10 +3787,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3478 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3478">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A cephalosporin bearing chloro and (R)-2-amino-2-phenylacetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3478">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A cephalosporin bearing chloro and (&lt;i&gt;R&lt;/i&gt;)-2-amino-2-phenylacetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:472656</oboInOwl:hasAlternativeId>
         <rdfs:label>cefaclor</rdfs:label>
     </owl:Class>
@@ -3801,10 +3799,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3479 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3479">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A cephalosporin bearing methyl and  (2R)-2-amino-2-(4-hydroxyphenyl)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3479">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A cephalosporin bearing methyl and  (2&lt;i&gt;R&lt;/i&gt;)-2-amino-2-(4-hydroxyphenyl)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefadroxil</rdfs:label>
     </owl:Class>
     
@@ -3812,11 +3810,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3480 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3480">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <obo:IAO_0000115>A cephalosporin compound having (R)-mandelamido and N-methylthiotetrazole side-groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3480">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <obo:IAO_0000115>A cephalosporin compound having (&lt;i&gt;R&lt;/i&gt;)-mandelamido and &lt;em&gt;N&lt;/em&gt;-methylthiotetrazole side-groups.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefamandole</rdfs:label>
     </owl:Class>
     
@@ -3824,11 +3822,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3485 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3485">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24983"/>
-        <obo:IAO_0000115>A cephalosporin compound having 7beta-2-(2-amino-thiazol-4-yl)-2-[(Z)-hydroxyimino]-acetylamino- and 3-vinyl side groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3485">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24983"/>
+        <obo:IAO_0000115>A cephalosporin compound having 7β-2-(2-amino-thiazol-4-yl)-2-[(Z)-hydroxyimino]-acetylamino- and 3-vinyl side groups.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:184624</oboInOwl:hasAlternativeId>
         <rdfs:label>cefdinir</rdfs:label>
     </owl:Class>
@@ -3837,10 +3835,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3489 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3489">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A second-generation cephalosporin antibiotic having N(1)-methyltetrazol-5-ylthiomethyl, {[(cyanomethyl)sulfanyl]acetyl}amino and methoxy side-groups at positions 3, 7beta and 7alpha respectively of the parent cephem bicyclic structure.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3489">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A second-generation cephalosporin antibiotic having &lt;em&gt;N&lt;/em&gt;&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;-methyltetrazol-5-ylthiomethyl, {[(cyanomethyl)sulfanyl]acetyl}amino and methoxy side-groups at positions 3, 7β and 7α respectively of the parent cephem bicyclic structure.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefmetazole</rdfs:label>
     </owl:Class>
     
@@ -3848,10 +3846,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3491 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3491">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A cephalosporin bearing {[1-(sulfomethyl)-1H-tetrazol-5-yl]sulfanyl}methyl and (R)-2-hydroxy-2-phenylacetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3491">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A cephalosporin bearing {[1-(sulfomethyl)-1&lt;em&gt;H&lt;/em&gt;-tetrazol-5-yl]sulfanyl}methyl and (&lt;i&gt;R&lt;/i&gt;)-2-hydroxy-2-phenylacetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefonicid</rdfs:label>
     </owl:Class>
     
@@ -3859,10 +3857,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3493 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3493">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3493">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
         <obo:IAO_0000115>A semi-synthetic parenteral cephalosporin with a tetrazolyl moiety that confers beta-lactamase resistance.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:258120</oboInOwl:hasAlternativeId>
         <rdfs:label>cefoperazone</rdfs:label>
     </owl:Class>
@@ -3871,15 +3869,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_34994 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_34994">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22160"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26195"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35618"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51026"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83403"/>
-        <obo:IAO_0000115>Any of the glycopeptides whose structure consists of teicoplanin A3-1 in which the hydroxy group of the di(aryloxy)-substituted phenol moiety has been converted to the corresponding 2-acylamino-2-deoxy-beta-D-glucoside. Members of the class differ only in the nature of the acyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_34994">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22160"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26195"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83403"/>
+        <obo:IAO_0000115>Any of the glycopeptides whose structure consists of teicoplanin A&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt;-1 in which the hydroxy group of the di(aryloxy)-substituted phenol moiety has been converted to the corresponding 2-acylamino-2-deoxy-β-&lt;small&gt;D&lt;/small&gt;-glucoside. Members of the class differ only in the nature of the acyl group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>teicoplanin A2</rdfs:label>
     </owl:Class>
     
@@ -3887,10 +3885,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_34996 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_34996">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_34994"/>
-        <obo:IAO_0000115>A teicoplanin A2 that has decanoyl as the variable N-acyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_34996">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_34994"/>
+        <obo:IAO_0000115>A teicoplanin A&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; that has decanoyl as the variable &lt;em&gt;N&lt;/em&gt;-acyl group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>teicoplanin A2-3</rdfs:label>
     </owl:Class>
     
@@ -3898,11 +3896,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3504 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3504">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3504">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
         <obo:IAO_0000115>A third-generation cephalosporin antibiotic with methoxymethyl and (2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetamino substituents at positions 3 and 7, respectively, of the cephem skeleton. Given by mouth as its proxetil ester prodrug, it is used to treat acute otitis media, pharyngitis, and sinusitis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:606443</oboInOwl:hasAlternativeId>
         <rdfs:label>cefpodoxime</rdfs:label>
     </owl:Class>
@@ -3911,11 +3909,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3506 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3506">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <obo:IAO_0000115>A semisynthetic, second-generation cephalosporin, with prop-1-enyl and (R)-2-amino-2-(4-hydroxyphenyl)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. It is used to treat bronchitis as well as ear, skin and other bacterial infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3506">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <obo:IAO_0000115>A semisynthetic, second-generation cephalosporin, with prop-1-enyl and (&lt;i&gt;R&lt;/i&gt;)-2-amino-2-(4-hydroxyphenyl)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. It is used to treat bronchitis as well as ear, skin and other bacterial infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefprozil</rdfs:label>
     </owl:Class>
     
@@ -3923,11 +3921,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3508 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3508">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36816"/>
-        <obo:IAO_0000115>A third-generation cephalosporin antibiotic bearing pyridinium-1-ylmethyl and {[(2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-{[(2-carboxypropan-2-yl)oxy]imino}acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3508">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36816"/>
+        <obo:IAO_0000115>A third-generation cephalosporin antibiotic bearing pyridinium-1-ylmethyl and {[(2&lt;i&gt;Z&lt;/i&gt;)-2-(2-amino-1,3-thiazol-4-yl)-2-{[(2-carboxypropan-2-yl)oxy]imino}acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ceftazidime</rdfs:label>
     </owl:Class>
     
@@ -3935,11 +3933,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3510 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3510">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35692"/>
-        <obo:IAO_0000115>A third-generation cephalosporin antibiotic with a [(2Z)-2-(2-amino-1,3-thiazol-4-yl)-4-carboxybut-2-enoyl]amino substituent at the 7 position of the cephem skeleton. An orally-administered agent, ceftibuten is used as the dihydrate to treat urinary-tract and respiratory-tract infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3510">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35692"/>
+        <obo:IAO_0000115>A third-generation cephalosporin antibiotic with a [(2&lt;i&gt;Z&lt;/i&gt;)-2-(2-amino-1,3-thiazol-4-yl)-4-carboxybut-2-enoyl]amino substituent at the 7 position of the cephem skeleton. An orally-administered agent, ceftibuten is used as the dihydrate to treat urinary-tract and respiratory-tract infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:554578</oboInOwl:hasAlternativeId>
         <rdfs:label>ceftibuten</rdfs:label>
     </owl:Class>
@@ -3948,10 +3946,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35156 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35156">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22985"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36364"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35156">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22985"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36364"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>calcium salt</rdfs:label>
     </owl:Class>
     
@@ -3959,11 +3957,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35213 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35213">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23643"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25000"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23643"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25000"/>
         <obo:IAO_0000115>A depsipeptide in which the amino and hydroxy carboxylic acid residues are connected in a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclodepsipeptide</rdfs:label>
     </owl:Class>
     
@@ -3971,12 +3969,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35275 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35275">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59793"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63161"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_73754"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35275">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59793"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63161"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_73754"/>
         <obo:IAO_0000115>A glycosyl compound arising formally from the elimination of water from a glycosidic hydroxy group and a S atom bound to a carbon atom, thus creating a C-S bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:22048</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:33577</oboInOwl:hasAlternativeId>
         <rdfs:label>S-glycosyl compound</rdfs:label>
@@ -3986,10 +3985,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35281 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35281">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27369"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35281">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27369"/>
         <obo:IAO_0000115>Neutral molecules having charge-separated forms with an onium atom which bears no hydrogen atoms and that is not adjacent to the anionic atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>onium betaine</rdfs:label>
     </owl:Class>
     
@@ -3997,10 +3996,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35285 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35285">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26469"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35281"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35285">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26469"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35281"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>iminium betaine</rdfs:label>
     </owl:Class>
     
@@ -4008,11 +4007,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35294 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35294">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33598"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35295"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35294">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33598"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35295"/>
         <obo:IAO_0000115>A polyclic compound in which all of the ring members are carbon atoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbopolycyclic compound</rdfs:label>
     </owl:Class>
     
@@ -4020,10 +4019,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35295 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35295">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33597"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33635"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33597"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33635"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>homopolycyclic compound</rdfs:label>
     </owl:Class>
     
@@ -4031,9 +4030,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35313 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35313">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35313">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hexoside</rdfs:label>
     </owl:Class>
     
@@ -4041,12 +4040,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3534 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3534">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A semisynthetic first-generation cephalosporin antibiotic having methyl and beta-(2R)-2-amino-2-phenylacetamido groups at the 3- and 7- of the cephem skeleton, respectively. It is effective against both Gram-negative and Gram-positive organisms, and is used for treatment of infections of the skin, respiratory tract and urinary tract.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3534">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A semisynthetic first-generation cephalosporin antibiotic having methyl and β-(2&lt;i&gt;R&lt;/i&gt;)-2-amino-2-phenylacetamido groups at the 3- and 7- of the cephem skeleton, respectively. It is effective against both Gram-negative and Gram-positive organisms, and is used for treatment of infections of the skin, respiratory tract and urinary tract.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cephalexin</rdfs:label>
     </owl:Class>
     
@@ -4054,11 +4053,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35341 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35341">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_18059"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51958"/>
-        <obo:IAO_0000115>Any of naturally occurring compounds and synthetic analogues, based on the cyclopenta[a]phenanthrene carbon skeleton, partially or completely hydrogenated; there are usually methyl groups at C-10 and C-13, and often an alkyl group at C-17. By extension, one or more bond scissions, ring expansions and/or ring contractions of the skeleton may have occurred. Natural steroids are derived biogenetically from squalene which is a triterpene.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35341">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18059"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51958"/>
+        <obo:IAO_0000115>Any of naturally occurring compounds and synthetic analogues, based on the cyclopenta[&lt;em&gt;a&lt;/em&gt;]phenanthrene carbon skeleton, partially or completely hydrogenated; there are usually methyl groups at C-10 and C-13, and often an alkyl group at C-17. By extension, one or more bond scissions, ring expansions and/or ring contractions of the skeleton may have occurred. Natural steroids are derived biogenetically from squalene which is a triterpene.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13687</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26768</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9263</oboInOwl:hasAlternativeId>
@@ -4069,10 +4068,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35350 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35350">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33822"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35341"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35350">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33822"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35341"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24748</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:5814</oboInOwl:hasAlternativeId>
         <rdfs:label>hydroxy steroid</rdfs:label>
@@ -4082,11 +4081,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35352 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35352">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35352">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
         <obo:IAO_0000115>Any heteroorganic entity containing at least one carbon-nitrogen bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organonitrogen compound</rdfs:label>
     </owl:Class>
     
@@ -4094,12 +4093,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35358 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35358">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33256"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33552"/>
-        <obo:IAO_0000115>An amide of a sulfonic acid RS(=O)2NR&apos;2.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35358">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33256"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33552"/>
+        <obo:IAO_0000115>An amide of a sulfonic acid RS(=O)&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;NR&apos;&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfonamide</rdfs:label>
     </owl:Class>
     
@@ -4107,10 +4106,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35362 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35362">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000115>Compounds derived from oxoacids RkE(=O)l(OH)m (l =/= 0) by replacing -OH  by -NRNR2 (R groups are commonly H). (IUPAC).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000115>Compounds derived from oxoacids R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH)&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt; (&lt;em&gt;l&lt;/em&gt; ≠ 0) by replacing ‒OH  by ‒NRNR&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; (R groups are commonly H). (IUPAC).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrazide</rdfs:label>
     </owl:Class>
     
@@ -4118,11 +4117,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35363 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35363">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35362"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35363">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35362"/>
         <obo:IAO_0000115>A hydrazide consisting of hydrazine carrying one or more carboacyl groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbohydrazide</rdfs:label>
     </owl:Class>
     
@@ -4130,11 +4129,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35406 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35406">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25741"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33273"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35406">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25741"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33273"/>
         <obo:IAO_0000115>An oxoanion is an anion derived from an oxoacid by loss of hydron(s) bound to oxygen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:33274</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:33436</oboInOwl:hasAlternativeId>
         <rdfs:label>oxoanion</rdfs:label>
@@ -4144,10 +4143,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35436 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35436">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24278"/>
-        <obo:IAO_0000115>Any glucoside in which the glycoside group is derived from D-glucose.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35436">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24278"/>
+        <obo:IAO_0000115>Any glucoside in which the glycoside group is derived from &lt;small&gt;D&lt;/small&gt;-glucose.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:21009</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:4173</oboInOwl:hasAlternativeId>
         <rdfs:label>D-glucoside</rdfs:label>
@@ -4157,11 +4156,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3547 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3547">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A first-generation cephalosporin antibiotic with a methyl substituent at position 3, and a (2R)-2-amino-2-cyclohexa-1,4-dien-1-ylacetamido substituent at position 7, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3547">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A first-generation cephalosporin antibiotic with a methyl substituent at position 3, and a (2&lt;i&gt;R&lt;/i&gt;)-2-amino-2-cyclohexa-1,4-dien-1-ylacetamido substituent at position 7, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cephradine</rdfs:label>
     </owl:Class>
     
@@ -4169,11 +4168,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35496 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35496">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22712"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37143"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35496">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22712"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37143"/>
         <obo:IAO_0000115>Any fluoroarene that is a benzene or a substituted benzene carrying at least one fluoro group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>fluorobenzenes</rdfs:label>
     </owl:Class>
     
@@ -4181,10 +4180,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35504 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35504">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35504">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
         <obo:IAO_0000115>An addition compound contains two or more simpler compounds that can be packed in a definite ratio into a crystal. The term covers donor-acceptor complexes (adducts) and a variety of lattice compounds.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>addition compound</rdfs:label>
     </owl:Class>
     
@@ -4192,10 +4191,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35505 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35505">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35504"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35505">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35504"/>
         <obo:IAO_0000115>An addition compound that contains water in weak chemical combination with another compound.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrate</rdfs:label>
     </owl:Class>
     
@@ -4203,9 +4202,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35507 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35507">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33245"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35507">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33245"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>natural product fundamental parent</rdfs:label>
     </owl:Class>
     
@@ -4213,12 +4212,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_355510 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_355510">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A cephalosporin with ({1-[2-(dimethylamino)ethyl]-1H-tetrazol-5-yl}sulfanyl)methyl and (2-amino-1,3-thiazol-4-yl)acetamido substituents at positions 3 and 7, respectively, of the cephem skeleton. A third generation beta-lactam cephalosporin antibiotic, it is active against a broad spectrum of both Gram positive and Gram negative bacteria.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_355510">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A cephalosporin with ({1-[2-(dimethylamino)ethyl]-1&lt;em&gt;H&lt;/em&gt;-tetrazol-5-yl}sulfanyl)methyl and (2-amino-1,3-thiazol-4-yl)acetamido substituents at positions 3 and 7, respectively, of the cephem skeleton. A third generation beta-lactam cephalosporin antibiotic, it is active against a broad spectrum of both Gram positive and Gram negative bacteria.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefotiam</rdfs:label>
     </owl:Class>
     
@@ -4226,9 +4225,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35552 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35552">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33245"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35552">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33245"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterocyclic organic fundamental parent</rdfs:label>
     </owl:Class>
     
@@ -4236,10 +4235,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35568 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35568">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35568">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>Any molecular entity that consists of a ring having (formally) the maximum number of noncumulative double bonds.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mancude ring</rdfs:label>
     </owl:Class>
     
@@ -4247,10 +4246,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35571 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35571">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35552"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35573"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35571">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35552"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35573"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mancude organic heterocyclic parent</rdfs:label>
     </owl:Class>
     
@@ -4258,10 +4257,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35573 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35573">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33245"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35568"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35573">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33245"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35568"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic mancude parent</rdfs:label>
     </owl:Class>
     
@@ -4269,10 +4268,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35605 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35605">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24833"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35605">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24833"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbon oxoacid</rdfs:label>
     </owl:Class>
     
@@ -4280,11 +4279,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35618 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35618">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25698"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35618">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25698"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
         <obo:IAO_0000115>Any ether in which the oxygen is attached to at least one aryl substituent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aromatic ether</rdfs:label>
     </owl:Class>
     
@@ -4292,10 +4291,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35627 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35627">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24995"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35627">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
         <obo:IAO_0000115>A lactam in which the amide bond is contained within a four-membered ring, which includes the amide nitrogen and the carbonyl carbon.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:10426</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13203</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22845</oboInOwl:hasAlternativeId>
@@ -4306,12 +4305,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35681 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35681">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <obo:IAO_0000115>A secondary alcohol is a compound in which a hydroxy group, -OH, is attached to a saturated carbon atom which has two other carbon atoms attached to it.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35681">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+        <obo:IAO_0000115>A secondary alcohol is a compound in which a hydroxy group, ‒OH, is attached to a saturated carbon atom which has two other carbon atoms attached to it.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13425</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13686</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:16339</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26617</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:58662</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8741</oboInOwl:hasAlternativeId>
@@ -4323,10 +4323,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35689 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35689">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35689">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole in which the five-membered heterocyclic aromatic skeleton contains four N atoms and one C atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tetrazoles</rdfs:label>
     </owl:Class>
     
@@ -4334,11 +4334,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35692 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35692">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_131927"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_131927"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
         <obo:IAO_0000115>Any carboxylic acid containing two carboxy groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:23692</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:36172</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:4501</oboInOwl:hasAlternativeId>
@@ -4349,10 +4349,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35701 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35701">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>A compound formally derived from an oxoacid RkE(=O)l(OH)m (l &gt; 0) and an alcohol, phenol, heteroarenol, or enol by linking with formal loss of water from an acidic hydroxy group of the former and a hydroxy group of the latter.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35701">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>A compound formally derived from an oxoacid R&lt;small&gt;&lt;sub&gt;&lt;em&gt;k&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;E(=O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;l&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(OH)&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt; (&lt;em&gt;l&lt;/em&gt; &gt; 0) and an alcohol, phenol, heteroarenol, or enol by linking with formal loss of water from an acidic hydroxy group of the former and a hydroxy group of the latter.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:23960</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:4859</oboInOwl:hasAlternativeId>
         <rdfs:label>ester</rdfs:label>
@@ -4362,10 +4362,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35715 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35715">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000115>A compound having a nitro group, -NO2 (free valence on nitrogen), which may be attached to carbon, nitrogen (as in nitramines), or oxygen (as in nitrates), among other elements (in the absence of specification, C-nitro compounds are usually implied).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35715">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000115>A compound having a nitro group, ‒NO&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; (free valence on nitrogen), which may be attached to carbon, nitrogen (as in nitramines), or oxygen (as in nitrates), among other elements (in the absence of specification, &lt;em&gt;C&lt;/em&gt;-nitro compounds are usually implied).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nitro compound</rdfs:label>
     </owl:Class>
     
@@ -4373,11 +4373,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35716 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35716">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35715"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72695"/>
-        <obo:IAO_0000115>A nitro compound having the nitro group (-NO2) attached to a carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35716">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35715"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72695"/>
+        <obo:IAO_0000115>A nitro compound having the nitro group (‒NO&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;) attached to a carbon atom.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>C-nitro compound</rdfs:label>
     </owl:Class>
     
@@ -4385,10 +4385,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35727 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35727">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole in which the five-membered heterocyclic aromatic skeleton contains three N atoms and two C atoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>triazoles</rdfs:label>
     </owl:Class>
     
@@ -4396,10 +4396,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35740 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35740">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_18059"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35740">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18059"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>liposaccharide</rdfs:label>
     </owl:Class>
     
@@ -4407,10 +4407,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35757 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35757">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29067"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35757">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29067"/>
         <obo:IAO_0000115>A carboxylic acid anion formed when the carboxy group of a monocarboxylic acid is deprotonated.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13657</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:25382</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3407</oboInOwl:hasAlternativeId>
@@ -4421,11 +4421,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35790 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35790">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35790">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole based on a five-membered heterocyclic aromatic skeleton containing one N and one O atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxazole</rdfs:label>
     </owl:Class>
     
@@ -4433,10 +4433,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35850 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35850">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <obo:IAO_0000115>An organosulfur compound having the structure RS(=O)2R (R =/= H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35850">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <obo:IAO_0000115>An organosulfur compound having the structure RS(=O)&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;R (R ≠ H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfone</rdfs:label>
     </owl:Class>
     
@@ -4444,11 +4444,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35871 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35871">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25754"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35871">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25754"/>
         <obo:IAO_0000115>Any monocarboxylic acid having at least one additional oxo functional group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxo monocarboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -4456,11 +4456,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35875 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35875">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33833"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35875">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33833"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imidazopyrimidine</rdfs:label>
     </owl:Class>
     
@@ -4468,13 +4468,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35915 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35915">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47880"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35915">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47880"/>
         <obo:IAO_0000115>A steroid ester obtained by formal condensation of the carboxy group of any carboxylic acid with the 3-hydroxy group of a sterol.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13220</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:15115</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>CHEBI:18213</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26770</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26772</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9268</oboInOwl:hasAlternativeId>
@@ -4486,10 +4487,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35990 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35990">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33635"/>
-        <obo:IAO_0000115>A polycyclic compound in which two rings have two or more atoms in common.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35990">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33635"/>
+        <obo:IAO_0000115>A polycyclic compound that contains more than one ring with at least two common atoms (also known as bridgehead carbons) that are not adjacent to each other.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>bridged compound</rdfs:label>
     </owl:Class>
     
@@ -4497,11 +4498,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35991 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35991">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35507"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35992"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35991">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35507"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35992"/>
         <obo:IAO_0000115>Compound comprising a beta-lactam ring fused to a saturated 5-membered ring containing one sulfur atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>penam</rdfs:label>
     </owl:Class>
     
@@ -4509,12 +4510,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_35992 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_35992">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38106"/>
-        <obo:IAO_0000115>Natural and synthetic antibiotics containing the 4-thia-1-azabicyclo[3.2.0]heptan-7-one structure, generally assumed to have the 5R configuration unless otherwise specified.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35992">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38106"/>
+        <obo:IAO_0000115>Natural and synthetic antibiotics containing the 4-thia-1-azabicyclo[3.2.0]heptan-7-one structure, generally assumed to have the 5&lt;i&gt;R&lt;/i&gt; configuration unless otherwise specified.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>penams</rdfs:label>
     </owl:Class>
     
@@ -4522,10 +4524,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36080 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36080">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33695"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36080">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33695"/>
         <obo:IAO_0000115>A biological macromolecule minimally consisting of one polypeptide chain synthesized at the ribosome.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13677</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:14911</oboInOwl:hasAlternativeId>
         <rdfs:label>protein</rdfs:label>
@@ -4535,10 +4537,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36094 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36094">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23114"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51069"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36094">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23114"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51069"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic chloride salt</rdfs:label>
     </owl:Class>
     
@@ -4546,10 +4548,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36357 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36357">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36357">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000115>Any molecular entity consisting of more than one atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyatomic entity</rdfs:label>
     </owl:Class>
     
@@ -4557,11 +4559,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36358 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36358">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24870"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36357"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36358">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24870"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
         <obo:IAO_0000115>An ion consisting of more than one atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polyatomic ion</rdfs:label>
     </owl:Class>
     
@@ -4569,10 +4571,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36359 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36359">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33241"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36360"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36359">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36360"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphorus oxoacid derivative</rdfs:label>
     </owl:Class>
     
@@ -4580,9 +4582,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36360 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36360">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26082"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36360">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26082"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phosphorus oxoacids and derivatives</rdfs:label>
     </owl:Class>
     
@@ -4590,10 +4592,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36364 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36364">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24866"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33299"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36364">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24866"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33299"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alkaline earth salt</rdfs:label>
     </owl:Class>
     
@@ -4601,10 +4603,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36416 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36416">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35571"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mancude organic heterotricyclic parent</rdfs:label>
     </owl:Class>
     
@@ -4612,12 +4614,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36420 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36420">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22213"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36416"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38180"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36420">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22213"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36416"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38180"/>
         <obo:IAO_0000115>A polycyclic heteroarene that is anthracene in which one of the central CH groups is replaced by a nitrogen atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>acridine</rdfs:label>
     </owl:Class>
     
@@ -4625,11 +4627,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36586 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36586">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36587"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36586">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36587"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
         <obo:IAO_0000115>Any compound containing the carbonyl group, C=O. The term is commonly used in the restricted sense of aldehydes and ketones, although it actually includes carboxylic acids and derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbonyl compound</rdfs:label>
     </owl:Class>
     
@@ -4637,10 +4639,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36587 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36587">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72695"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36587">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72695"/>
         <obo:IAO_0000115>Organic compounds containing an oxygen atom, =O, doubly bonded to carbon or another element.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic oxo compound</rdfs:label>
     </owl:Class>
     
@@ -4648,11 +4650,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36683 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36683">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17792"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23117"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36683">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17792"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23117"/>
         <obo:IAO_0000115>An organochlorine compound is a compound containing at least one carbon-chlorine bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organochlorine compound</rdfs:label>
     </owl:Class>
     
@@ -4660,9 +4662,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36688 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36688">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33671"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36688">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33671"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterotricyclic compound</rdfs:label>
     </owl:Class>
     
@@ -4670,11 +4672,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36709 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36709">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36709">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33860"/>
         <obo:IAO_0000115>Any member of the class of quinolines in which the quinoline skeleton is substituted by one or more amino or substituted-amino groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aminoquinoline</rdfs:label>
     </owl:Class>
     
@@ -4682,11 +4684,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36785 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36785">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33636"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35294"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36785">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33636"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35294"/>
         <obo:IAO_0000115>A bicyclic compound in which all the ring atoms are carbon.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbobicyclic compound</rdfs:label>
     </owl:Class>
     
@@ -4694,10 +4696,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36807 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36807">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36094"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36807">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36094"/>
         <obo:IAO_0000115>A salt formally resulting from the reaction of hydrochloric acid with an organic base.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrochloride</rdfs:label>
     </owl:Class>
     
@@ -4705,11 +4707,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36816 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36816">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25698"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <obo:IAO_0000115>O-organyl oximes R2C=NOR&apos; (R&apos; =/= H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36816">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25698"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <obo:IAO_0000115>&lt;em&gt;O&lt;/em&gt;-organyl oximes R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C=NOR&apos; (R&apos; ≠ H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxime O-ether</rdfs:label>
     </owl:Class>
     
@@ -4717,10 +4719,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36834 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36834">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35350"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36834">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35350"/>
         <obo:IAO_0000115>Any hydroxy steroid carrying a hydroxy group at position 3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>3-hydroxy steroid</rdfs:label>
     </owl:Class>
     
@@ -4728,11 +4730,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36835 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36835">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35681"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36834"/>
-        <obo:IAO_0000115>A 3-hydroxy steroid in which the 3-hydroxy substituent is in the alpha-position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36835">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36834"/>
+        <obo:IAO_0000115>A 3-hydroxy steroid in which the 3-hydroxy substituent is in the α-position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:71194</oboInOwl:hasAlternativeId>
         <rdfs:label>3alpha-hydroxy steroid</rdfs:label>
     </owl:Class>
@@ -4741,9 +4743,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36841 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36841">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35350"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36841">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35350"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>11-hydroxy steroid</rdfs:label>
     </owl:Class>
     
@@ -4751,10 +4753,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36914 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36914">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24835"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24870"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36914">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24835"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24870"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>inorganic ion</rdfs:label>
     </owl:Class>
     
@@ -4762,11 +4764,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36962 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36962">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33304"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36962">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33304"/>
         <obo:IAO_0000115>An organochalcogen compound is a compound containing at least one carbon-chalcogen bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organochalcogen compound</rdfs:label>
     </owl:Class>
     
@@ -4774,11 +4776,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_36963 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36963">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25806"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36962"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36963">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36962"/>
         <obo:IAO_0000115>An organochalcogen compound containing at least one carbon-oxygen bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organooxygen compound</rdfs:label>
     </owl:Class>
     
@@ -4786,11 +4788,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37141 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37141">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17792"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22928"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37141">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17792"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22928"/>
         <obo:IAO_0000115>A compound containing at least one carbon-bromine bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organobromine compound</rdfs:label>
     </owl:Class>
     
@@ -4798,11 +4800,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37143 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37143">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17792"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24062"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37143">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17792"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24062"/>
         <obo:IAO_0000115>An organofluorine compound is a compound containing at least one carbon-fluorine bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organofluorine compound</rdfs:label>
     </owl:Class>
     
@@ -4810,12 +4812,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3716 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3716">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25754"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38770"/>
-        <obo:IAO_0000115>A member of the class of  cinnolines  that is 6,7-methylenedioxycinnolin-4(1H)-one bearing an ethyl group at position 1 and a carboxylic acid group at position 3. An analogue of oxolinic acid, it has similar antibacterial actions. It was formerly used for the treatment of urinary tract infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3716">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25754"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38770"/>
+        <obo:IAO_0000115>A member of the class of  cinnolines  that is 6,7-methylenedioxycinnolin-4(1&lt;em&gt;H&lt;/em&gt;)-one bearing an ethyl group at position 1 and a carboxylic acid group at position 3. An analogue of oxolinic acid, it has similar antibacterial actions. It was formerly used for the treatment of urinary tract infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:314701</oboInOwl:hasAlternativeId>
         <rdfs:label>cinoxacin</rdfs:label>
     </owl:Class>
@@ -4824,9 +4826,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37175 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37175">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33692"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37175">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33692"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic hydride</rdfs:label>
     </owl:Class>
     
@@ -4834,10 +4836,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3732 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3732">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <obo:IAO_0000115>The 6-O-methyl ether of erythromycin A, clarithromycin is a macrolide antibiotic used in the treatment of respiratory-tract, skin and soft-tissue infections. It is also used to eradicate Helicobacter pylori in the treatment of peptic ulcer disease. It prevents bacteria from growing by interfering with their protein synthesis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3732">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <obo:IAO_0000115>The 6-&lt;em&gt;O&lt;/em&gt;-methyl ether of erythromycin A, clarithromycin is a macrolide antibiotic used in the treatment of respiratory-tract, skin and soft-tissue infections. It is also used to eradicate &lt;em&gt;Helicobacter pylori&lt;/em&gt; in the treatment of peptic ulcer disease. It prevents bacteria from growing by interfering with their protein synthesis.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:41676</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:442148</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:670147</oboInOwl:hasAlternativeId>
@@ -4848,11 +4850,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37407 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37407">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25698"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37407">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25698"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Any ether in which the oxygen atom forms part of a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:37406</oboInOwl:hasAlternativeId>
         <rdfs:label>cyclic ether</rdfs:label>
     </owl:Class>
@@ -4861,14 +4863,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3745 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3745">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23007"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35275"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36683"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46770"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3745">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23007"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35275"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36683"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
         <obo:IAO_0000115>A carbohydrate-containing antibiotic that is the  semisynthetic derivative of lincomycin, a natural antibiotic.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:47331</oboInOwl:hasAlternativeId>
         <rdfs:label>clindamycin</rdfs:label>
     </owl:Class>
@@ -4877,11 +4879,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3749 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3749">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39201"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83403"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3749">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39201"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83403"/>
         <obo:IAO_0000115>3-Isopropylimino-3,5-dihydro-phenazine in which the hydrogen at position 5 is substituted substituted by a 4-chlorophenyl group, and that at position 2 is substituted by a (4-chlorophenyl)amino group. A dark red crystalline solid, clofazimine is an antimycobacterial and is one of the main drugs used for the treatment of  multi-bacillary leprosy. However, it can cause red/brown discolouration of the skin, so other treatments are often preferred in light-skinned patients.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:355347</oboInOwl:hasAlternativeId>
         <rdfs:label>clofazimine</rdfs:label>
     </owl:Class>
@@ -4890,10 +4892,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37577 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37577">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36357"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37577">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
         <obo:IAO_0000115>A molecular entity consisting of two or more chemical elements.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteroatomic molecular entity</rdfs:label>
     </owl:Class>
     
@@ -4901,11 +4903,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37578 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37578">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24471"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37577"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37578">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24471"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
         <obo:IAO_0000115>Any heteroatomic molecular entity that is a chemical compound of halogen with other chemical elements.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>halide</rdfs:label>
     </owl:Class>
     
@@ -4913,12 +4915,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37622 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37622">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33256"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>An amide of a carboxylic acid, having the structure RC(=O)NR2. The term is used as a suffix in systematic name formation to denote the -C(=O)NH2 group including its carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37622">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33256"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>An amide of a carboxylic acid, having the structure RC(=O)NR&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;. The term is used as a suffix in systematic name formation to denote the ‒C(=O)NH&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; group including its carbon atom.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:35354</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:35355</oboInOwl:hasAlternativeId>
         <rdfs:label>carboxamide</rdfs:label>
@@ -4928,10 +4930,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37716 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37716">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24782"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37716">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24782"/>
         <obo:IAO_0000115>Any imide in which the acyl substituents are any two from carboacyl, sulfonyl and phosphoryl</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mixed diacylamine</rdfs:label>
     </owl:Class>
     
@@ -4939,10 +4941,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37734 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37734">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26079"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35701"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37734">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26079"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26019</oboInOwl:hasAlternativeId>
         <rdfs:label>phosphoric ester</rdfs:label>
     </owl:Class>
@@ -4951,9 +4953,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37773 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37773">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25703"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37773">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25703"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic phosphoramidate</rdfs:label>
     </owl:Class>
     
@@ -4961,10 +4963,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37912 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37912">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23403"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37912">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23403"/>
         <obo:IAO_0000115>Any coumarin carrying at least one hydroxy substituent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:24691</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:24692</oboInOwl:hasAlternativeId>
         <rdfs:label>hydroxycoumarin</rdfs:label>
@@ -4974,10 +4976,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37922 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37922">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24951"/>
-        <obo:IAO_0000115>A kanamycin that is kanamycin B bearing an N-(2S)-4-amino-2-hydroxybutyryl group on the aminocyclitol ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37922">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24951"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47779"/>
+        <obo:IAO_0000115>A kanamycin that is kanamycin B bearing an &lt;em&gt;N&lt;/em&gt;-(2&lt;i&gt;S&lt;/i&gt;)-4-amino-2-hydroxybutyryl group on the aminocyclitol ring.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>arbekacin</rdfs:label>
     </owl:Class>
     
@@ -4985,14 +4988,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37923 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37923">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23824"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50994"/>
-        <obo:IAO_0000115>An amino cyclitol glycoside that is L-chiro-inositol in which the hydroxy groups at positions 1, 4, and 6 are replaced by aminoacetyl)methylamino, amino, and methoxy groups, respectively, and in which the hydroxy group at position 3 is converted to the corresponding 2,6-diamino-2,3,4,6,7-pentadeoxy-beta-L-lyxo-heptopyranoside. The major component of fortimicin, obtained from Micromonospora olivasterospora. It is administered (as the sulfate salt) by intramuscular injection or intravenous infusion for the treatment of severe systemic infections due to sensitive Gram-negative organisms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37923">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23824"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50994"/>
+        <obo:IAO_0000115>An amino cyclitol glycoside that is &lt;small&gt;L&lt;/small&gt;-&lt;em&gt;chiro&lt;/em&gt;-inositol in which the hydroxy groups at positions 1, 4, and 6 are replaced by aminoacetyl)methylamino, amino, and methoxy groups, respectively, and in which the hydroxy group at position 3 is converted to the corresponding 2,6-diamino-2,3,4,6,7-pentadeoxy-β-&lt;small&gt;L&lt;/small&gt;-&lt;i&gt;lyxo&lt;/i&gt;-heptopyranoside. The major component of fortimicin, obtained from &lt;em&gt;Micromonospora olivasterospora&lt;/em&gt;. It is administered (as the sulfate salt) by intramuscular injection or intravenous infusion for the treatment of severe systemic infections due to sensitive Gram-negative organisms.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>astromicin</rdfs:label>
     </owl:Class>
     
@@ -5000,10 +5003,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_37945 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_37945">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24951"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37945">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24951"/>
         <obo:IAO_0000115>A kanamycin that is kanamycin B lacking the 3- and 4-hydroxy groups on the 2,6-diaminosugar ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dibekacin</rdfs:label>
     </owl:Class>
     
@@ -5011,11 +5014,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38032 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38032">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35294"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51959"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35294"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51959"/>
         <obo:IAO_0000115>A carbopolyclic compound comprising of three carbocyclic rings.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbotricyclic compound</rdfs:label>
     </owl:Class>
     
@@ -5023,10 +5026,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38064 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38064">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_62732"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38064">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_62732"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heteroarenecarboxylate ester</rdfs:label>
     </owl:Class>
     
@@ -5034,9 +5037,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38099 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38099">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38099">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiadiazoles</rdfs:label>
     </owl:Class>
     
@@ -5044,11 +5047,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38101 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38101">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38101">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
         <obo:IAO_0000115>Any organonitrogen compound containing a cyclic component with nitrogen and at least one other element as ring member atoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organonitrogen heterocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -5056,11 +5059,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38102 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38102">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50893"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38102">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50893"/>
         <obo:IAO_0000115>Compounds based on a triazine skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>triazines</rdfs:label>
     </owl:Class>
     
@@ -5068,11 +5072,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38104 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38104">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38104">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
         <obo:IAO_0000115>Any organic heterocyclic compound containing at least one ring oxygen atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxacycle</rdfs:label>
     </owl:Class>
     
@@ -5080,10 +5084,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38106 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38106">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38106">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organosulfur heterocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -5091,10 +5095,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38131 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38131">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5653"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38131">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5653"/>
         <obo:IAO_0000115>Cyclic hemiacetals formed by intramolecular addition of a hydroxy group to an aldehydic or ketonic carbonyl group. They are thus 1-oxacycloalkan-2-ols or unsaturated analogues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lactol</rdfs:label>
     </owl:Class>
     
@@ -5102,9 +5106,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38163 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38163">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38163">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heterotetracyclic compound</rdfs:label>
     </owl:Class>
     
@@ -5112,10 +5116,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38166 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38166">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33671"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38166">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33671"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25429</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:38075</oboInOwl:hasAlternativeId>
         <rdfs:label>organic heteropolycyclic compound</rdfs:label>
@@ -5125,9 +5129,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38179 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38179">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33833"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38179">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33833"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monocyclic heteroarene</rdfs:label>
     </owl:Class>
     
@@ -5135,9 +5139,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38180 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38180">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33833"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38180">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33833"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polycyclic heteroarene</rdfs:label>
     </owl:Class>
     
@@ -5145,11 +5149,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38260 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38260">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any of a class of heterocyclic amines having a saturated five-membered ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26922</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:38191</oboInOwl:hasAlternativeId>
         <rdfs:label>pyrrolidines</rdfs:label>
@@ -5159,9 +5163,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38261 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38261">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38304"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38261">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38304"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imidazolidines</rdfs:label>
     </owl:Class>
     
@@ -5169,10 +5173,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38295 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38295">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>azabicycloalkane</rdfs:label>
     </owl:Class>
     
@@ -5180,10 +5184,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38304 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38304">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38304">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diazolidine</rdfs:label>
     </owl:Class>
     
@@ -5191,11 +5195,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38311 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38311">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38106"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38311">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35627"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38106"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cephem</rdfs:label>
     </owl:Class>
     
@@ -5203,11 +5209,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38313 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38313">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38313">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any organic heterocyclic compound containing a benzene ring in which two of the C-H fragments have been replaced by isolobal nitrogens (the diazine parent structure).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diazines</rdfs:label>
     </owl:Class>
     
@@ -5215,9 +5221,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38314 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38314">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38313"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38314">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38313"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyrazines</rdfs:label>
     </owl:Class>
     
@@ -5225,11 +5231,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38329 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38329">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38329">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxazolidines</rdfs:label>
     </owl:Class>
     
@@ -5237,10 +5243,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_383703 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_383703">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36094"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_383703">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36094"/>
         <obo:IAO_0000115>The 10-methochloride salt of 3,6-diaminoacridine. Note that a mixture of this compound with 3,6-diaminoacridine (proflavine) is known as acriflavine or neutral acriflavine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>3,6-diamino-10-methylacridinium chloride</rdfs:label>
     </owl:Class>
     
@@ -5248,9 +5254,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38418 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38418">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_48901"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_48901"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26949</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:38417</oboInOwl:hasAlternativeId>
         <rdfs:label>1,3-thiazoles</rdfs:label>
@@ -5260,9 +5266,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38443 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38443">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22727"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38443">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22727"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>1-benzopyran</rdfs:label>
     </owl:Class>
     
@@ -5270,9 +5276,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38445 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38445">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23232"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38445">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23232"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chromenone</rdfs:label>
     </owl:Class>
     
@@ -5280,10 +5286,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38532 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38532">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <obo:IAO_0000115>Compounds having the structure R2C=NNR2, formally derived from aldehydes or ketones by replacing =O by =NNH2 (or substituted analogues).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38532">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <obo:IAO_0000115>Compounds having the structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C=NNR&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;, formally derived from aldehydes or ketones by replacing =O by =NNH&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; (or substituted analogues).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydrazone</rdfs:label>
     </owl:Class>
     
@@ -5291,10 +5297,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38582 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38582">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35496"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38582">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35496"/>
         <obo:IAO_0000115>Any member of the class of fluorobenzenes containing a mono- or poly-substituted benzene ring carrying two fluorine atoms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>difluorobenzene</rdfs:label>
     </owl:Class>
     
@@ -5302,11 +5308,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38770 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38770">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38770">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
         <obo:IAO_0000115>Any  organic heteropolycyclic compound based on the 1,2-diaza analogue of naphthalene and its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cinnolines</rdfs:label>
     </owl:Class>
     
@@ -5314,10 +5320,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_38785 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_38785">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46952"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38785">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46952"/>
         <obo:IAO_0000115>Any compound containing morpholine as part of its structure.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>morpholines</rdfs:label>
     </owl:Class>
     
@@ -5325,14 +5331,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3907 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3907">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23403"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26455"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38064"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_62733"/>
-        <obo:IAO_0000115>A hydroxycoumarin antibiotic that is obtained from Streptomyces rishiriensis and exhibits potent antibacterial and anticancer activity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3907">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23403"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26455"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38064"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_62733"/>
+        <obo:IAO_0000115>A hydroxycoumarin antibiotic that is obtained from &lt;em&gt;Streptomyces rishiriensis&lt;/em&gt; and exhibits potent antibacterial and anticancer activity.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>coumermycin A1</rdfs:label>
     </owl:Class>
     
@@ -5340,11 +5346,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_39201 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_39201">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_39201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any  organonitrogen heterocyclic compound based on a phenazine skeleton and derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>phenazines</rdfs:label>
     </owl:Class>
     
@@ -5352,10 +5358,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_39206 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_39206">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_39206">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dibenzopyridine</rdfs:label>
     </owl:Class>
     
@@ -5363,10 +5369,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_39270 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_39270">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_39270">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>naphthofuran</rdfs:label>
     </owl:Class>
     
@@ -5374,10 +5380,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_39410 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_39410">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38102"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_39410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38102"/>
         <obo:IAO_0000115>Any compound with a 1,2,4-triazine skeleton, in which nitrogen atoms replace carbon at positions 1, 2 and 4 of the core benzene ring structure.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>1,2,4-triazines</rdfs:label>
     </owl:Class>
     
@@ -5385,10 +5391,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_39447 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_39447">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38313"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_39447">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38313"/>
         <obo:IAO_0000115>Any compound having a pyrimidine as part of its structure.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13681</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:26448</oboInOwl:hasAlternativeId>
         <rdfs:label>pyrimidines</rdfs:label>
@@ -5398,9 +5404,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_3992 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_3992">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17087"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3992">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17087"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic ketone</rdfs:label>
     </owl:Class>
     
@@ -5408,12 +5414,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_40009 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_40009">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23503"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25558"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25807"/>
-        <obo:IAO_0000115>A 4-amino-1,2-oxazolidin-3-one that has R configuration. It is an antibiotic produced by Streptomyces garyphalus or S. orchidaceus and is used as part of a multi-drug regimen for the treatment of tuberculosis when resistance to, or toxicity from, primary drugs has developed. An analogue of D-alanine, it interferes with bacterial cell wall synthesis in the cytoplasm by competitive inhibition of L-alanine racemase (which forms D-alanine from L-alanine) and  D-alanine--D-alanine ligase (which incorporates D-alanine into the pentapeptide required for peptidoglycan formation and bacterial cell wall synthesis).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_40009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23503"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25807"/>
+        <obo:IAO_0000115>A 4-amino-1,2-oxazolidin-3-one that has &lt;i&gt;R&lt;/i&gt; configuration. It is an antibiotic produced by &lt;em&gt;Streptomyces garyphalus&lt;/em&gt; or &lt;em&gt;S. orchidaceus&lt;/em&gt; and is used as part of a multi-drug regimen for the treatment of tuberculosis when resistance to, or toxicity from, primary drugs has developed. An analogue of &lt;small&gt;D&lt;/small&gt;-alanine, it interferes with bacterial cell wall synthesis in the cytoplasm by competitive inhibition of &lt;small&gt;L&lt;/small&gt;-alanine racemase (which forms &lt;small&gt;D&lt;/small&gt;-alanine from &lt;small&gt;L&lt;/small&gt;-alanine) and  &lt;small&gt;D&lt;/small&gt;-alanine—&lt;small&gt;D&lt;/small&gt;-alanine ligase (which incorporates &lt;small&gt;D&lt;/small&gt;-alanine into the pentapeptide required for peptidoglycan formation and bacterial cell wall synthesis).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:4030</oboInOwl:hasAlternativeId>
         <rdfs:label>D-cycloserine</rdfs:label>
     </owl:Class>
@@ -5422,11 +5428,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_404903 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_404903">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46634"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46770"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_404903">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46634"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46770"/>
         <obo:IAO_0000115>Meropenem in which the one of the two methyl groups attached to the amide nitrogen is replaced by hydrogen while the other is replaced by a 3-carboxyphenyl group. The sodium salt is used for the treatment of moderate to severe susceptible infections including intra-abdominal  and acute gynaecological infections, pneumonia, and infections of the skin and of the urinary tract.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:471574</oboInOwl:hasAlternativeId>
         <rdfs:label>ertapenem</rdfs:label>
     </owl:Class>
@@ -5435,18 +5441,20 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4309 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4309">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_140325"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_140326"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35681"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35850"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_3992"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46812"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51751"/>
-        <obo:IAO_0000115>A macrolide that is pristinamycin IIA in which the double bond between positions 26 and 26a of the pyrroline ring has been reduced and position 26R carries a [2-(diethylamino)ethyl]sulfonyl group. It is a semi-synthetic streptogramin antibiotic and often used as a mixture with quinupristin for the treatment of vancomycin-resistant Enterococcus faecium.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_140325"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_140326"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35850"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_3992"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46812"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51751"/>
+        <obo:IAO_0000115>A macrolide that is pristinamycin IIA in which the double bond between positions 26 and 26a of the pyrroline ring has been reduced and position 26&lt;i&gt;R&lt;/i&gt; carries a [2-(diethylamino)ethyl]sulfonyl group. It is a semi-synthetic streptogramin antibiotic and often used as a mixture with quinupristin for the treatment of vancomycin-resistant &lt;em&gt;Enterococcus faecium&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:42127</oboInOwl:hasAlternativeId>
         <rdfs:label>dalfopristin</rdfs:label>
     </owl:Class>
@@ -5455,13 +5463,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_43968 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_43968">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16385"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46634"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46770"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_79020"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_43968">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16385"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46634"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_79020"/>
         <obo:IAO_0000115>A carbapenemcarboxylic acid in which the azetidine and pyrroline rings carry 1-hydroxymethyl and in which the azetidine and pyrroline rings carry 1-hydroxymethyl and 5-(dimethylcarbamoyl)pyrrolidin-3-ylthio substituents respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>meropenem</rdfs:label>
     </owl:Class>
     
@@ -5469,11 +5477,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_443725 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_443725">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24650"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26069"/>
-        <obo:IAO_0000115>Propylphosphonic acid in which one of the hydrogens at position 3 is substituted by a formyl(hydroxy)amino group. An antibiotic obtained from Streptomyces lavendulae, it specifically inhibits DXP reductoisomerase (EC 1.1.1.267), a key enzyme in the non-mevalonate pathway of isoprenoid biosynthesis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_443725">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24650"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26069"/>
+        <obo:IAO_0000115>Propylphosphonic acid in which one of the hydrogens at position 3 is substituted by a formyl(hydroxy)amino group. An antibiotic obtained from &lt;em&gt;Streptomyces lavendulae&lt;/em&gt;, it specifically inhibits DXP reductoisomerase (EC 1.1.1.267), a key enzyme in the non-mevalonate pathway of isoprenoid biosynthesis.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:42526</oboInOwl:hasAlternativeId>
         <rdfs:label>fosmidomycin</rdfs:label>
     </owl:Class>
@@ -5482,9 +5490,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4454 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4454">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_61689"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4454">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_61689"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Destomysin</rdfs:label>
     </owl:Class>
     
@@ -5492,11 +5500,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4511 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4511">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17334"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23697"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4511">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23697"/>
         <obo:IAO_0000115>A penicillin that is 6-aminopenicillanic acid in which one of the amino hydrogens is replaced by a 3-(2,6-dichlorophenyl)-5-methyl-1,2-oxazol-4-yl]formyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dicloxacillin</rdfs:label>
     </owl:Class>
     
@@ -5504,11 +5512,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_45257 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_45257">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <obo:IAO_0000115>An amino cyclitol glycoside that is 4,6-diaminocyclohexane-1,2,3-triol having a 2,6-diamino-2,6-dideoxy-alpha-D-glucosyl residue attached at position 1 and a beta-D-ribosyl residue attached at position 2. It is an antibiotic produced by Streptomyces ribosidificus (formerly S. thermoflavus).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_45257">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <obo:IAO_0000115>An amino cyclitol glycoside that is 4,6-diaminocyclohexane-1,2,3-triol having a 2,6-diamino-2,6-dideoxy-α-&lt;small&gt;D&lt;/small&gt;-glucosyl residue attached at position 1 and a β-&lt;small&gt;D&lt;/small&gt;-ribosyl residue attached at position 2. It is an antibiotic produced by &lt;em&gt;Streptomyces ribosidificus&lt;/em&gt; (formerly &lt;em&gt;S. thermoflavus&lt;/em&gt;).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ribostamycin</rdfs:label>
     </owl:Class>
     
@@ -5516,12 +5524,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_45285 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_45285">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38314"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83628"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_45285">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83628"/>
         <obo:IAO_0000115>A monocarboxylic acid amide resulting from the formal condensation of the carboxy group of pyrazinoic acid (pyrazine-2-carboxylic acid) with ammonia. A prodrug for pyrazinoic acid, pyrazinecarboxamide is used as part of multidrug regimens for the treatment of tuberculosis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:45281</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8656</oboInOwl:hasAlternativeId>
         <rdfs:label>pyrazinecarboxamide</rdfs:label>
@@ -5531,9 +5539,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_45367 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_45367">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26580"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_45367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26580"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:45364</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:8857</oboInOwl:hasAlternativeId>
         <rdfs:label>rifabutin</rdfs:label>
@@ -5543,11 +5551,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46633 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46633">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <obo:IAO_0000115>The class of beta-lactam antibiotics that whose members have a carbapenem skeleton which is variously substituted at positions 3, 4, and 6.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46633">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000115>The class of β-lactam antibiotics that whose members have a carbapenem skeleton which is variously substituted at positions 3, 4, and 6.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbapenems</rdfs:label>
     </owl:Class>
     
@@ -5555,10 +5564,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46634 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46634">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46633"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46634">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46633"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbapenemcarboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -5566,10 +5575,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46770 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46770">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_29347"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38260"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46770">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38260"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyrrolidinecarboxamide</rdfs:label>
     </owl:Class>
     
@@ -5577,9 +5586,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46812 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46812">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35790"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46812">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35790"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>1,3-oxazoles</rdfs:label>
     </owl:Class>
     
@@ -5587,10 +5596,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46845 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46845">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26144"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46845">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26144"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-alkylpiperazine</rdfs:label>
     </owl:Class>
     
@@ -5598,9 +5607,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46847 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46847">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26144"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46847">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26144"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-iminopiperazine</rdfs:label>
     </owl:Class>
     
@@ -5608,11 +5617,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46848 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46848">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26144"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33860"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46848">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26144"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33860"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-arylpiperazine</rdfs:label>
     </owl:Class>
     
@@ -5620,11 +5629,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46895 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46895">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16670"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_18059"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46895">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16670"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18059"/>
         <obo:IAO_0000115>A compound consisting of a peptide with attached lipid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lipopeptide</rdfs:label>
     </owl:Class>
     
@@ -5632,9 +5641,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46920 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46920">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46845"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46920">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46845"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-methylpiperazine</rdfs:label>
     </owl:Class>
     
@@ -5642,11 +5652,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46942 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46942">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46942">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
         <obo:IAO_0000115>Any organic heteromonocyclic compoundthat is oxane or its substituted derivatives.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxanes</rdfs:label>
     </owl:Class>
     
@@ -5654,11 +5664,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_46952 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_46952">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25693"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46952">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxazinane</rdfs:label>
     </owl:Class>
     
@@ -5666,9 +5676,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47017 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47017">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26912"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26912"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tetrahydrofuranol</rdfs:label>
     </owl:Class>
     
@@ -5676,9 +5686,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47019 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47019">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47017"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47017"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dihydroxytetrahydrofuran</rdfs:label>
     </owl:Class>
     
@@ -5686,9 +5696,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4705 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4705">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_16991"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4705">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16991"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>double-stranded DNA</rdfs:label>
     </owl:Class>
     
@@ -5696,11 +5706,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_471744 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_471744">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46633"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A broad-spectrum, intravenous beta-lactam antibiotic of the carbapenem subgroup.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_471744">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46633"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A broad-spectrum, intravenous β-lactam antibiotic of the carbapenem subgroup.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:5879</oboInOwl:hasAlternativeId>
         <rdfs:label>imipenem</rdfs:label>
     </owl:Class>
@@ -5709,10 +5719,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_472657 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_472657">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A third-generation cephalosporin antibiotic bearing vinyl and (2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-[(carboxymethoxy)imino]acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. It is used in the treatment of gonorrhoea, tonsilitis, pharyngitis, bronchitis, and urinary tract infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_472657">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A third-generation cephalosporin antibiotic bearing vinyl and (2&lt;i&gt;Z&lt;/i&gt;)-2-(2-amino-1,3-thiazol-4-yl)-2-[(carboxymethoxy)imino]acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. It is used in the treatment of gonorrhoea, tonsilitis, pharyngitis, bronchitis, and urinary tract infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3487</oboInOwl:hasAlternativeId>
         <rdfs:label>cefixime</rdfs:label>
     </owl:Class>
@@ -5721,10 +5731,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_474014 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_474014">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <obo:IAO_0000115>The hemi-aminal resulting from the condensation of the erythromycin derivative (9S)-erythromycyclamine with 2-(2-methoxyethoxy)acetaldehyde. As the oxazine ring containing the hemi-aminal group is unstable under both acidic and alkaline conditions, dirithromycin functions as a more lipid-soluble prodrug for (9S)-erythromycyclamine. Administered as enteric coated tablets to protect it from acid catalysed hydrolysis in the stomach, it is used to treat respiratory tract, skin, and soft tissue infections caused by susceptible organisms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_474014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <obo:IAO_0000115>The hemi-aminal resulting from the condensation of the erythromycin derivative (9&lt;i&gt;S&lt;/i&gt;)-erythromycyclamine with 2-(2-methoxyethoxy)acetaldehyde. As the oxazine ring containing the hemi-aminal group is unstable under both acidic and alkaline conditions, dirithromycin functions as a more lipid-soluble prodrug for (9&lt;i&gt;S&lt;/i&gt;)-erythromycyclamine. Administered as enteric coated tablets to protect it from acid catalysed hydrolysis in the stomach, it is used to treat respiratory tract, skin, and soft tissue infections caused by susceptible organisms.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dirithromycin</rdfs:label>
     </owl:Class>
     
@@ -5732,13 +5742,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_474053 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_474053">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35689"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38099"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88225"/>
-        <obo:IAO_0000115>A first-generation cephalosporin compound having [(5-methyl-1,3,4-thiadiazol-2-yl)sulfanyl]methyl and (1H-tetrazol-1-ylacetyl)amino side-groups at positions 3 and 7 respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_474053">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38099"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88225"/>
+        <obo:IAO_0000115>A first-generation cephalosporin compound having [(5-methyl-1,3,4-thiadiazol-2-yl)sulfanyl]methyl and (1&lt;em&gt;H&lt;/em&gt;-tetrazol-1-ylacetyl)amino side-groups at positions 3 and 7 respectively.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3482</oboInOwl:hasAlternativeId>
         <rdfs:label>cefazolin</rdfs:label>
     </owl:Class>
@@ -5747,10 +5757,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47622 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47622">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47622">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
         <obo:IAO_0000115>Any carboxylic ester where the carboxylic acid component is acetic acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13244</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:13799</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:22189</oboInOwl:hasAlternativeId>
@@ -5762,9 +5772,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47779 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47779">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47779">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aminoglycoside</rdfs:label>
     </owl:Class>
     
@@ -5772,11 +5783,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_478164 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_478164">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36816"/>
-        <obo:IAO_0000115>A cephalosporin bearing (1-methylpyrrolidinium-1-yl)methyl and (2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_478164">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36816"/>
+        <obo:IAO_0000115>A cephalosporin bearing (1-methylpyrrolidinium-1-yl)methyl and (2&lt;i&gt;Z&lt;/i&gt;)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3486</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:473919</oboInOwl:hasAlternativeId>
         <rdfs:label>cefepime</rdfs:label>
@@ -5786,10 +5797,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47880 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47880">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35341"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35701"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47880">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:26762</oboInOwl:hasAlternativeId>
         <rdfs:label>steroid ester</rdfs:label>
     </owl:Class>
@@ -5798,9 +5809,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47881 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47881">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35871"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47881">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35871"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:13600</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:1619</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:35949</oboInOwl:hasAlternativeId>
@@ -5811,11 +5822,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47891 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47891">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35341"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_64709"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47891">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_64709"/>
         <obo:IAO_0000115>Any steroid substituted by at least one carboxy group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>steroid acid</rdfs:label>
     </owl:Class>
     
@@ -5823,10 +5834,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_47956 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_47956">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33256"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_47956">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33256"/>
         <obo:IAO_0000115>Any primary amide having its amide oxygen replaced by sulfur.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiocarboxamide</rdfs:label>
     </owl:Class>
     
@@ -5834,11 +5845,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4877 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4877">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23981"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_31577"/>
-        <obo:IAO_0000115>An ethylenediamine derivative that is ethane-1,2-diamine in which one hydrogen attached to each of the nitrogens is sutstituted by a 1-hydroxybutan-2-yl group (S,S-configuration). It is a bacteriostatic antimycobacterial drug, effective against Mycobacterium tuberculosis and some other mycobacteria. It is used (as the dihydrochloride salt) in combination with other antituberculous drugs in the treatment of pulmonary and extrapulmonary tuberculosis; resistant strains of M. tuberculosis are readily produced if ethambutol is used alone.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4877">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23981"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_31577"/>
+        <obo:IAO_0000115>An ethylenediamine derivative that is ethane-1,2-diamine in which one hydrogen attached to each of the nitrogens is sutstituted by a 1-hydroxybutan-2-yl group (&lt;i&gt;S&lt;/i&gt;,&lt;i&gt;S&lt;/i&gt;-configuration). It is a bacteriostatic antimycobacterial drug, effective against &lt;em&gt;Mycobacterium tuberculosis&lt;/em&gt; and some other mycobacteria. It is used (as the dihydrochloride salt) in combination with other antituberculous drugs in the treatment of pulmonary and extrapulmonary tuberculosis; resistant strains of &lt;em&gt;M. tuberculosis&lt;/em&gt; are readily produced if ethambutol is used alone.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:133410</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:659237</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:678172</oboInOwl:hasAlternativeId>
@@ -5849,10 +5860,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_487869 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_487869">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35757"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_487869">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35757"/>
         <obo:IAO_0000115>The conjugate base of clavulanic acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>clavulanate</rdfs:label>
     </owl:Class>
     
@@ -5860,9 +5871,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48838 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48838">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32583"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48838">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32583"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>gypsum</rdfs:label>
     </owl:Class>
     
@@ -5870,11 +5881,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48844 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48844">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_48924"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48844">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_48924"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
         <obo:IAO_0000115>Semisynthetic derivative of erythromycin A.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>roxithromycin</rdfs:label>
     </owl:Class>
     
@@ -5882,11 +5894,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_4885 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_4885">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26421"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47956"/>
-        <obo:IAO_0000115>A thiocarboxamide that is pyridine-4-carbothioamide substituted by an ethyl group at position 2. A prodrug that undergoes metabolic activation by conversion to the corresponding S-oxide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_4885">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26421"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47956"/>
+        <obo:IAO_0000115>A thiocarboxamide that is pyridine-4-carbothioamide substituted by an ethyl group at position 2. A prodrug that undergoes metabolic activation by conversion to the corresponding &lt;em&gt;S&lt;/em&gt;-oxide.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ethionamide</rdfs:label>
     </owl:Class>
     
@@ -5894,11 +5906,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48901 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48901">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38106"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_68452"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48901">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_68452"/>
         <obo:IAO_0000115>An azole in which the five-membered heterocyclic aromatic skeleton contains a N atom and one S atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiazoles</rdfs:label>
     </owl:Class>
     
@@ -5906,9 +5918,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48924 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48924">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23953"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48924">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23953"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>erythromycin derivative</rdfs:label>
     </owl:Class>
     
@@ -5916,10 +5928,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48947 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48947">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_64509"/>
-        <obo:IAO_0000115>Antibiotic isolated from Streptomyces clavuligerus. It acts as a suicide inhibitor of bacterial beta-lactamase enzymes.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48947">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_64509"/>
+        <obo:IAO_0000115>Antibiotic isolated from &lt;em&gt;Streptomyces clavuligerus&lt;/em&gt;. It acts as a suicide inhibitor of bacterial β-lactamase enzymes.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3736</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:43442</oboInOwl:hasAlternativeId>
         <rdfs:label>clavulanic acid</rdfs:label>
@@ -5929,9 +5941,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_48975 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_48975">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22562"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_48975">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22562"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>substituted aniline</rdfs:label>
     </owl:Class>
     
@@ -5939,9 +5951,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_49319 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_49319">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33598"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_49319">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbocyclic antibiotic</rdfs:label>
     </owl:Class>
     
@@ -5949,11 +5961,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_49566 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_49566">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_49566">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A semisynthetic penicillin antibiotic carrying a 3-(2-chlorophenyl)-5-methylisoxazole-4-carboxamido group at position 6.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3765</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:49565</oboInOwl:hasAlternativeId>
         <rdfs:label>cloxacillin</rdfs:label>
@@ -5963,10 +5976,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50047 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50047">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50047">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>A compound formally derived from ammonia by replacing one, two or three hydrogen atoms by organyl groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic amino compound</rdfs:label>
     </owl:Class>
     
@@ -5974,15 +5988,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50199 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50199">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46845"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50199">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46845"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A quinolone that is 4-oxo-1,4-dihydroquinoline which is substituted at positions 1, 3, 6 and 7 by ethyl, carboxy, fluorine, and 4-methylpiperazin-1-yl groups, respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pefloxacin</rdfs:label>
     </owl:Class>
     
@@ -5990,10 +6004,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50695 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50695">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50695">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
         <obo:IAO_0000115>Monocyclic, bacterially produced or semisynthetic beta-lactam antibiotic. It lacks the double ring construction of the traditional beta-lactam antibiotics and can be easily synthesized.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monobactam</rdfs:label>
     </owl:Class>
     
@@ -6001,10 +6015,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50860 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50860">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33582"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50860">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33582"/>
         <obo:IAO_0000115>Any molecular entity that contains carbon.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25700</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:33244</oboInOwl:hasAlternativeId>
         <rdfs:label>organic molecular entity</rdfs:label>
@@ -6014,10 +6028,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50893 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50893">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33833"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50893">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33833"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>azaarene</rdfs:label>
     </owl:Class>
     
@@ -6025,9 +6039,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50896 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50896">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50896">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>azabicycloalkene</rdfs:label>
     </owl:Class>
     
@@ -6035,10 +6049,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50954 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50954">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22632"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50954">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22632"/>
         <obo:IAO_0000115>Compounds with structure RAs=AsR.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>diarsenes</rdfs:label>
     </owl:Class>
     
@@ -6046,10 +6060,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5098 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5098">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
-        <obo:IAO_0000115>A penicillin compound having a 6beta-[3-(2-chloro-6-fluorophenyl)-5-methyl-1,2-oxazole-4-carboxamido] side-chain.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
+        <obo:IAO_0000115>A penicillin compound having a 6β-[3-(2-chloro-6-fluorophenyl)-5-methyl-1,2-oxazole-4-carboxamido] side-chain.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>flucloxacillin</rdfs:label>
     </owl:Class>
     
@@ -6057,10 +6072,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50994 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50994">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50994">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>A compound formally derived from ammonia by replacing one hydrogen atom by an organyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>primary amino compound</rdfs:label>
     </owl:Class>
     
@@ -6068,10 +6083,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50995 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50995">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50995">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>A compound formally derived from ammonia by replacing two hydrogen atoms by organyl groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>secondary amino compound</rdfs:label>
     </owl:Class>
     
@@ -6079,10 +6094,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_50996 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_50996">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50047"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50996">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50047"/>
         <obo:IAO_0000115>A compound formally derived from ammonia by replacing three hydrogen atoms by organyl groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tertiary amino compound</rdfs:label>
     </owl:Class>
     
@@ -6090,10 +6105,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51026 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51026">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
         <obo:IAO_0000115>A cyclic compound containing nine or more atoms as part of the cyclic system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>macrocycle</rdfs:label>
     </owl:Class>
     
@@ -6101,9 +6116,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51069 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51069">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24868"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51069">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24868"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic halide salt</rdfs:label>
     </owl:Class>
     
@@ -6111,9 +6126,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51143 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51143">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33302"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51143">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25556</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7594</oboInOwl:hasAlternativeId>
         <rdfs:label>nitrogen molecular entity</rdfs:label>
@@ -6123,10 +6138,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51151 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51151">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72695"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51151">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72695"/>
         <obo:IAO_0000115>An  organic molecule that is electrically neutral carrying a positive and a negative charge in one of its major canonical descriptions. In most dipolar compounds the charges are delocalized; however the term is also applied to species where this is not the case.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>dipolar compound</rdfs:label>
     </owl:Class>
     
@@ -6134,10 +6149,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51454 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51454">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33598"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51454">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33598"/>
         <obo:IAO_0000115>Cyclopropane and its derivatives formed by substitution.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclopropanes</rdfs:label>
     </owl:Class>
     
@@ -6145,11 +6160,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51689 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51689">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51721"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_78840"/>
-        <obo:IAO_0000115>An alpha,beta-unsaturated ketone of general formula R(1)R(2)C=CR(3)-C(=O)R(4) (R(4) =/= H) in which the C=O function is conjugated to a C=C double bond at the alpha,beta position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51689">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51721"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_78840"/>
+        <obo:IAO_0000115>An α,β-unsaturated ketone of general formula R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;C=CR&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt;‒C(=O)R&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; (R&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; ≠ H) in which the C=O function is conjugated to a C=C double bond at the α,β position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>enone</rdfs:label>
     </owl:Class>
     
@@ -6157,10 +6172,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51721 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51721">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17087"/>
-        <obo:IAO_0000115>A ketone of general formula R(1)R(2)C=CR(3)-C(=O)R(4) (R(4) =/= H) or R(1)C#C-C(=O)R(2) (R(2) =/= H) in which the ketonic C=O function is conjugated to an unsaturated C-C bond at the alpha,beta position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51721">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17087"/>
+        <obo:IAO_0000115>A ketone of general formula R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;C=CR&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt;‒C(=O)R&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; (R&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; ≠ H) or R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;C≡C‒C(=O)R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; (R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; ≠ H) in which the ketonic C=O function is conjugated to an unsaturated C-C bond at the α,β position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha,beta-unsaturated ketone</rdfs:label>
     </owl:Class>
     
@@ -6168,10 +6183,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51737 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51737">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <obo:IAO_0000115>A carboxylic ester of general formula R(1)R(2)C=CR(3)-C(=O)OR(4) (R(4) =/= H) or R(1)C#C-C(=O)OR(2) (R(2) =/= H) in which the ester C=O function is conjugated to an unsaturated C-C bond at the alpha,beta position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51737">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <obo:IAO_0000115>A carboxylic ester of general formula R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;C=CR&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt;‒C(=O)OR&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; (R&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt; ≠ H) or R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;C≡C‒C(=O)OR&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; (R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; ≠ H) in which the ester C=O function is conjugated to an unsaturated C-C bond at the α,β position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha,beta-unsaturated carboxylic ester</rdfs:label>
     </owl:Class>
     
@@ -6179,10 +6194,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51750 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51750">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
-        <obo:IAO_0000115>A monocarboxylic amide of general formula R(1)R(2)C=CR(3)-C(=O)NR(4)R(5)  or R(1)C#C-C(=O)NR(2)R(3) in which the amide C=O function is conjugated to an unsaturated C-C bond at the alpha,beta position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51750">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
+        <obo:IAO_0000115>A monocarboxylic amide of general formula R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;C=CR&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt;‒C(=O)NR&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;5&lt;/small&gt;&lt;/sup&gt;  or R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;C≡C‒C(=O)NR&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt; in which the amide C=O function is conjugated to an unsaturated C-C bond at the α,β position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha,beta-unsaturated carboxylic acid amide</rdfs:label>
     </owl:Class>
     
@@ -6190,11 +6205,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51751 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51751">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51750"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_78840"/>
-        <obo:IAO_0000115>An alpha,beta-unsaturated carboxylic acid amide of general formula R(1)R(2)C=CR(3)-C(=O)NR(4)R(5) in which the amide C=O function is conjugated to a C=C double bond at the alpha,beta position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51751">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51750"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_78840"/>
+        <obo:IAO_0000115>An α,β-unsaturated carboxylic acid amide of general formula R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt;C=CR&lt;small&gt;&lt;sup&gt;3&lt;/small&gt;&lt;/sup&gt;‒C(=O)NR&lt;small&gt;&lt;sup&gt;4&lt;/small&gt;&lt;/sup&gt;R&lt;small&gt;&lt;sup&gt;5&lt;/small&gt;&lt;/sup&gt; in which the amide C=O function is conjugated to a C=C double bond at the α,β position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>enamide</rdfs:label>
     </owl:Class>
     
@@ -6202,9 +6217,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51914 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51914">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38166"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51914">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic heterohexacyclic compound</rdfs:label>
     </owl:Class>
     
@@ -6212,11 +6227,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5195 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5195">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38329"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87230"/>
-        <obo:IAO_0000115>A member of the class of oxazolidines that is 1,3-oxazolidin-2-one in which the hydrogen attached to the nitrogen is replaced by an N-{[(5-nitro-2-furyl)methylene]amino} group. It has antibacterial and antiprotozoal properties, and is used in the treatment of giardiasis and cholera.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5195">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38329"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87230"/>
+        <obo:IAO_0000115>A member of the class of oxazolidines that is 1,3-oxazolidin-2-one in which the hydrogen attached to the nitrogen is replaced by an &lt;em&gt;N&lt;/em&gt;-{[(5-nitro-2-furyl)methylene]amino} group. It has antibacterial and antiprotozoal properties, and is used in the treatment of giardiasis and cholera.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>furazolidone</rdfs:label>
     </owl:Class>
     
@@ -6224,10 +6239,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51958 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51958">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33635"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33832"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51958">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33635"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33832"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic polycyclic compound</rdfs:label>
     </owl:Class>
     
@@ -6235,9 +6250,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_51959 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_51959">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51958"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_51959">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51958"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic tricyclic compound</rdfs:label>
     </owl:Class>
     
@@ -6245,41 +6260,20 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_52211 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_52211">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24432"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24432"/>
+        <obo:IAO_0000115>A biological role relating to the normal mechanisms and their interactions within a living system.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>physiological role</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CHEBI_52395 -->
-
-    <owl:Class rdf:about="&obo;CHEBI_52395">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17087"/>
-        <obo:IAO_0000115>A compound with the general formula R2C=O (R=/=H) where one or more of the R groups contains an oxy (-O-) group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
-        <rdfs:label>oxyketone</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CHEBI_52396 -->
-
-    <owl:Class rdf:about="&obo;CHEBI_52396">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_52395"/>
-        <obo:IAO_0000115>An oxyketone with the general formula R2C(=O) (R=/=H) where one or more of the R groups contains an oxy (-O-) group and the oxy and carbonyl groups are bonded to the same carbon atom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
-        <rdfs:label>alpha-oxyketone</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_52429 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_52429">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17334"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52429">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>propicillin</rdfs:label>
     </owl:Class>
     
@@ -6287,14 +6281,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5280 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5280">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37143"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5280">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37143"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
         <obo:IAO_0000115>A monocarboxylic acid that is 4-oxo-1,4-dihydroquinoline-3-carboxylic acid which is substituted on the nitrogen by a cyclopropyl group and at positions 6, 7, and 8 by fluoro, 3-methylpiperazin-1-yl, and methoxy groups, respectively. Gatifloxacin is an antibiotic of the fourth-generation fluoroquinolone family, that like other members of that family, inhibits the bacterial topoisomerase type-II enzymes.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:101712</oboInOwl:hasAlternativeId>
         <rdfs:label>gatifloxacin</rdfs:label>
     </owl:Class>
@@ -6303,10 +6297,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_52898 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_52898">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51026"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52898">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
         <obo:IAO_0000115>A cyclic macromolecule containing one or more nitrogen atoms in place of carbon either as the divalent group NH for the group CH2 or a single trivalent nitrogen atom for the group CH.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>azamacrocycle</rdfs:label>
     </owl:Class>
     
@@ -6314,10 +6308,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_53665 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_53665">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26979"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_53665">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26979"/>
         <obo:IAO_0000115>Any organic heterotricyclic compound based on a skeleton comprised of an oxazine ring fused onto a quinoline system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxazinoquinoline</rdfs:label>
     </owl:Class>
     
@@ -6325,9 +6319,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5530 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5530">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24613"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5530">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24613"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>gramicidin S</rdfs:label>
     </owl:Class>
     
@@ -6335,10 +6329,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_553473 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_553473">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <obo:IAO_0000115>A parenteral third-generation cephalosporin, bearing a 2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetyl]amino group at the 7beta-position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_553473">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <obo:IAO_0000115>A parenteral third-generation cephalosporin, bearing a 2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetyl]amino group at the 7β-position.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:112105</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:3511</oboInOwl:hasAlternativeId>
         <rdfs:label>ceftizoxime</rdfs:label>
@@ -6348,10 +6342,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55370 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55370">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38261"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55370">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38261"/>
         <obo:IAO_0000115>An imidazolidine containing one or more oxo groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>imidazolidinone</rdfs:label>
     </owl:Class>
     
@@ -6359,10 +6353,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55373 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55373">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35790"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55373">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35790"/>
         <obo:IAO_0000115>Oxazoles in which the N and O atoms are adjacent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:46813</oboInOwl:hasAlternativeId>
         <rdfs:label>isoxazoles</rdfs:label>
     </owl:Class>
@@ -6371,10 +6365,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55374 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55374">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38329"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55374">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38329"/>
         <obo:IAO_0000115>An oxazolidine containing one or more oxo groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxazolidinone</rdfs:label>
     </owl:Class>
     
@@ -6382,10 +6376,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55429 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55429">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38311"/>
-        <obo:IAO_0000115>Any member of the cephamycin sub-group of cephem antibiotics, differing from cephalosporins in possessing a methoxy group at the 7alpha-position of the cephem nucleus, and in being resistant to beta-lactamase.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55429">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38311"/>
+        <obo:IAO_0000115>Any member of the cephamycin sub-group of cephem antibiotics, differing from cephalosporins in possessing a methoxy group at the 7α-position of the cephem nucleus, and in being resistant to β-lactamase.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cephamycin</rdfs:label>
     </owl:Class>
     
@@ -6393,11 +6387,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5543 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5543">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5543">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Grepafloxacin</rdfs:label>
     </owl:Class>
     
@@ -6405,10 +6399,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_554446 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_554446">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_554446">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
         <obo:IAO_0000115>A cephalosporin with  acetoxymethyl and 2(pyridin-4-ylsulfanyl)acetamido substituents at positions 3 and 7, respectively, of the cephem skeleton. It is used (as its sodium salt) as an antibiotic, being effective against gram-negative and gram-positive organisms.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3544</oboInOwl:hasAlternativeId>
         <rdfs:label>cephapirin</rdfs:label>
     </owl:Class>
@@ -6417,11 +6411,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55504 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55504">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <obo:IAO_0000115>Any member of a group of synthetic antibiotics, similar to cephems but with carbon substituted for the sulfur; all possessing an acylated amine functionality at C-6 and (S,R) stereochemistry at C-6 and C-7.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55504">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000115>Any member of a group of synthetic antibiotics, similar to cephems but with carbon substituted for the sulfur; all possessing an acylated amine functionality at C-6 and (&lt;i&gt;S&lt;/i&gt;,&lt;i&gt;R&lt;/i&gt;) stereochemistry at C-6 and C-7.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbacephem</rdfs:label>
     </owl:Class>
     
@@ -6429,11 +6424,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_55506 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_55506">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <obo:IAO_0000115>Any member of the oxacephem sub-group of cephem antibiotics, in which the thiaazabicyclo moiety of the cephalosporins is replaced by an oxaazabicyclo moiety, and  where R3 is -H or -OCH3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55506">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000115>Any member of the oxacephem sub-group of cephem antibiotics, in which the thiaazabicyclo moiety of the cephalosporins is replaced by an oxaazabicyclo moiety, and  where R&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt; is -H or -OCH&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxacephem</rdfs:label>
     </owl:Class>
     
@@ -6441,10 +6437,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5653 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5653">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_30879"/>
-        <obo:IAO_0000115>A compound having the general formula RR&apos;C(OH)OR&apos;&apos; (R&apos;&apos; =/= H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5653">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+        <obo:IAO_0000115>A compound having the general formula RR&apos;C(OH)OR&apos;&apos; (R&apos;&apos; ≠ H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hemiacetal</rdfs:label>
     </owl:Class>
     
@@ -6452,10 +6448,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5686 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5686">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33595"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5686">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33595"/>
         <obo:IAO_0000115>A cyclic compound having as ring members atoms of at least two different elements.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>heterocyclic compound</rdfs:label>
     </owl:Class>
     
@@ -6463,9 +6459,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_5880 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_5880">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_5880">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Imipenem-cilastatin</rdfs:label>
     </owl:Class>
     
@@ -6473,11 +6469,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59062 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59062">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24533"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46895"/>
-        <obo:IAO_0000115>Polymyxins are antibiotics with a general structure consisting of a cyclic peptide with a long hydrophobic tail. They disrupt the structure of the bacterial cell membrane by interacting with its phospholipids. Polymyxins are produced by the Gram-positive bacterium Bacillus polymyxa and are selectively toxic for Gram-negative bacteria.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24533"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46895"/>
+        <obo:IAO_0000115>Polymyxins are antibiotics with a general structure consisting of a cyclic peptide with a long hydrophobic tail. They disrupt the structure of the bacterial cell membrane by interacting with its phospholipids. Polymyxins are produced by the Gram-positive bacterium &lt;em&gt;Bacillus polymyxa&lt;/em&gt; and are selectively toxic for Gram-negative bacteria.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polymyxin</rdfs:label>
     </owl:Class>
     
@@ -6485,10 +6481,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59063 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59063">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59062"/>
-        <obo:IAO_0000115>A polymyxin having a 6-methylheptanoyl group at the amino terminus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59063">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59062"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polymyxin B2</rdfs:label>
     </owl:Class>
     
@@ -6496,11 +6491,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59064 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59064">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59062"/>
-        <obo:IAO_0000115>A polymyxin having a (6R)-6-methyloctanoyl group at the amino terminus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59064">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59062"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>colistin A</rdfs:label>
     </owl:Class>
     
@@ -6508,10 +6502,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59132 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59132">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24432"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59132">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24432"/>
         <obo:IAO_0000115>Any substance that stimulates an immune response in the body, such as through antibody production or by presentation to a T-cell receptor after binding to a major histocompability complex (MHC).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>antigen</rdfs:label>
     </owl:Class>
     
@@ -6519,11 +6513,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59343 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59343">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33575"/>
-        <obo:IAO_0000115>A broad spectrum, third-generation cephalosporin antibiotic with (Z)-2-(4-methyl-1,3-thiazol-5-yl)ethenyl and (2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. Generally administered as its orally absorbed pivaloyloxymethyl ester prodrug, it is used for the treatment of mild to moderate infections caused by susceptible strains of microorganisms in acute bacterial exacerbation of chronic bronchitis, community-acquired pneumonia, pharyngitis/tonsillitis, and uncomplicated skin and skin-structure infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59343">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33575"/>
+        <obo:IAO_0000115>A broad spectrum, third-generation cephalosporin antibiotic with (&lt;i&gt;Z&lt;/i&gt;)-2-(4-methyl-1,3-thiazol-5-yl)ethenyl and (2&lt;i&gt;Z&lt;/i&gt;)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetamido groups at positions 3 and 7, respectively, of the cephem skeleton. Generally administered as its orally absorbed pivaloyloxymethyl ester prodrug, it is used for the treatment of mild to moderate infections caused by susceptible strains of microorganisms in acute bacterial exacerbation of chronic bronchitis, community-acquired pneumonia, pharyngitis/tonsillitis, and uncomplicated skin and skin-structure infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cefditoren</rdfs:label>
     </owl:Class>
     
@@ -6531,11 +6525,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59673 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59673">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25903"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59062"/>
-        <obo:IAO_0000115>A polymyxin having a 6-methylheptanoyl group at the amino terminus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59673">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25903"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59062"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>colistin B</rdfs:label>
     </owl:Class>
     
@@ -6543,10 +6536,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59769 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59769">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>An organooxygen compound having the structure RR&apos;C(OR&apos;&apos;)(OR&apos;&apos;&apos;) (R&apos;&apos;, R&apos;&apos;&apos; =/= H). Mixed acetals have R&apos;&apos; and R&apos;&apos;&apos; groups which differ.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59769">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>An organooxygen compound having the structure RR&apos;C(OR&apos;&apos;)(OR&apos;&apos;&apos;) (R&apos;&apos;, R&apos;&apos;&apos; ≠ H). Mixed acetals have R&apos;&apos; and R&apos;&apos;&apos; groups which differ.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>acetal</rdfs:label>
     </owl:Class>
     
@@ -6554,11 +6547,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59770 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59770">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24532"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59769"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59770">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59769"/>
         <obo:IAO_0000115>An acetal in the molecule of which the acetal carbon and one or both oxygen atoms thereon are members of a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic acetal</rdfs:label>
     </owl:Class>
     
@@ -6566,10 +6559,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59772 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59772">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_5653"/>
-        <obo:IAO_0000115>A hemiacetal having the structure RR(1)C(OH)OR(2) (R, R(1), R(2) =/= H), derived from a ketone by formal addition of an alcohol to the carbonyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59772">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_5653"/>
+        <obo:IAO_0000115>A hemiacetal having the structure RR&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;C(OH)OR&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; (R, R&lt;small&gt;&lt;sup&gt;1&lt;/small&gt;&lt;/sup&gt;, R&lt;small&gt;&lt;sup&gt;2&lt;/small&gt;&lt;/sup&gt; ≠ H), derived from a ketone by formal addition of an alcohol to the carbonyl group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hemiketal</rdfs:label>
     </owl:Class>
     
@@ -6577,10 +6570,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59777 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59777">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59769"/>
-        <obo:IAO_0000115>An acetal of formula R2C(OR)2 (R =/= H) derived from a ketone by replacement of the oxo group by two hydrocarbyloxy groups. The class name &apos;ketals&apos;, once abandoned by IUPAC, has been reinstated as a subclass of acetals.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59777">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59769"/>
+        <obo:IAO_0000115>An acetal of formula R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C(OR)&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; (R ≠ H) derived from a ketone by replacement of the oxo group by two hydrocarbyloxy groups. The class name &apos;ketals&apos;, once abandoned by IUPAC, has been reinstated as a subclass of acetals.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ketal</rdfs:label>
     </owl:Class>
     
@@ -6588,11 +6581,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59779 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59779">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38104"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59777"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59779">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59777"/>
         <obo:IAO_0000115>A ketal in the molecule of which the ketal carbon and one or both oxygen atoms thereon are members of a ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic ketal</rdfs:label>
     </owl:Class>
     
@@ -6600,11 +6593,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59780 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59780">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38131"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59772"/>
-        <obo:IAO_0000115>A hemiacetal  having the structure R2C(OH)OR (R =/= H), derived from a ketone by formal addition of an alcohol to the carbonyl group. The term &apos;cyclic hemiketals&apos;, once abandoned by IUPAC, has been reinstated as a subclass of hemiacetals.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59780">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38131"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59772"/>
+        <obo:IAO_0000115>A hemiacetal  having the structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C(OH)OR (R ≠ H), derived from a ketone by formal addition of an alcohol to the carbonyl group. The term &apos;cyclic hemiketals&apos;, once abandoned by IUPAC, has been reinstated as a subclass of hemiacetals.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>cyclic hemiketal</rdfs:label>
     </owl:Class>
     
@@ -6612,10 +6605,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59792 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59792">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <obo:IAO_0000115>The sulfur analogue of &apos;acetal&apos;.  The term includes monothioacetals having the structure R2C(OR&apos;)(SR&apos;) (subclass monothioketals, R =/= H); and dithioacetals having the structure R2C(SR&apos;)2 (subclass dithioketals, R =/= H, R&apos; =/= H).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59792">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <obo:IAO_0000115>The sulfur analogue of &apos;acetal&apos;.  The term includes monothioacetals having the structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C(OR&apos;)(SR&apos;) (subclass monothioketals, R ≠ H); and dithioacetals having the structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C(SR&apos;)&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt; (subclass dithioketals, R ≠ H, R&apos; ≠ H).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thioacetal</rdfs:label>
     </owl:Class>
     
@@ -6623,10 +6616,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59793 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59793">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59792"/>
-        <obo:IAO_0000115>A thioacetal having the structure R2C(OR&apos;)(SR&apos;). The term includes monothioketals, R =/= H, as a subclass.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59793">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59792"/>
+        <obo:IAO_0000115>A thioacetal having the structure R&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;C(OR&apos;)(SR&apos;). The term includes monothioketals, R ≠ H, as a subclass.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monothioacetal</rdfs:label>
     </owl:Class>
     
@@ -6634,11 +6627,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_599928 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_599928">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55506"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_599928">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55506"/>
         <obo:IAO_0000115>A broad-spectrum oxacephem antibiotic in which the oxazine ring is substituted with a tetrazolylthiomethyl group and the azetidinone ring carries methoxy and 2-carboxy-2-(4-hydroxyphenyl)acetamido substituents.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:214506</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:44113</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:7006</oboInOwl:hasAlternativeId>
@@ -6649,10 +6642,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_59999 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_59999">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24431"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_59999">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
         <obo:IAO_0000115>A chemical substance is a portion of matter of constant composition, composed of molecular entities of the same type or of different types.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>chemical substance</rdfs:label>
     </owl:Class>
     
@@ -6660,10 +6653,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_60004 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_60004">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59999"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_60004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59999"/>
         <obo:IAO_0000115>A mixture is a chemical substance composed of multiple molecules, at least two of which are of a different kind.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mixture</rdfs:label>
     </owl:Class>
     
@@ -6671,12 +6664,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_600103 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_600103">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24533"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25061"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <obo:IAO_0000115>A polypeptide comprising N-decanoyltryptophan, asparagine, aspartic acid, threonine, glycine, ornithine, aspartic acid, D-alanine, aspartic acid, glycine, D-serine, threo-3-methylglutamic acid and 3-anthraniloylalanine (also known as kynurinine) coupled in sequence and lactonised by condensation of the carboxylic acid group of the 3-anthraniloylalanine  with the alcohol group of the threonine residue.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_600103">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24533"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25061"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46895"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
+        <obo:IAO_0000115>A polypeptide comprising &lt;em&gt;N&lt;/em&gt;-decanoyltryptophan, asparagine, aspartic acid, threonine, glycine, ornithine, aspartic acid, &lt;small&gt;D&lt;/small&gt;-alanine, aspartic acid, glycine, &lt;small&gt;D&lt;/small&gt;-serine, &lt;em&gt;threo&lt;/em&gt;-3-methylglutamic acid and 3-anthraniloylalanine (also known as kynurinine) coupled in sequence and lactonised by condensation of the carboxylic acid group of the 3-anthraniloylalanine  with the alcohol group of the threonine residue.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:29570</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:321017</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:478132</oboInOwl:hasAlternativeId>
@@ -6688,10 +6683,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6030 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6030">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35363"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35363"/>
         <obo:IAO_0000115>A carbohydrazide obtained by formal condensation between pyridine-4-carboxylic acid and hydrazine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>isoniazide</rdfs:label>
     </owl:Class>
     
@@ -6699,11 +6694,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_60584 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_60584">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35990"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38295"/>
-        <obo:IAO_0000115>A commercially important azabicyclic antibiotic obtained from Streptomyces sapporonensis. It inhibits the Rho protein of E. coli.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_60584">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35990"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38295"/>
+        <obo:IAO_0000115>A commercially important azabicyclic antibiotic obtained from &lt;em&gt;Streptomyces sapporonensis&lt;/em&gt;. It inhibits the Rho protein of &lt;em&gt;E. coli&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:3091</oboInOwl:hasAlternativeId>
         <rdfs:label>bicozamycin</rdfs:label>
     </owl:Class>
@@ -6712,10 +6707,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_60911 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_60911">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_60004"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_60911">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_60004"/>
         <obo:IAO_0000115>A racemate is an equimolar mixture of a pair of enantiomers.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>racemate</rdfs:label>
     </owl:Class>
     
@@ -6723,10 +6718,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_60979 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_60979">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24278"/>
-        <obo:IAO_0000115>A glucoside in which the anomeric carbon of the glycosidic bond is in an alpha configuration</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_60979">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24278"/>
+        <obo:IAO_0000115>A glucoside in which the anomeric carbon of the glycosidic bond is in an α configuration</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha-glucoside</rdfs:label>
     </owl:Class>
     
@@ -6734,10 +6729,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6104 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6104">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24951"/>
-        <obo:IAO_0000115>Kanamycin is a naturally occurring antibiotic complex from Streptomyces kanamyceticus that consists of several components: kanamycin A, the major component (also usually designated as kanamycin), and kanamycins B, C, D and X the minor components.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6104">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24951"/>
+        <obo:IAO_0000115>Kanamycin is a naturally occurring antibiotic complex from &lt;em&gt;Streptomyces kanamyceticus&lt;/em&gt; that consists of several components: kanamycin A, the major component (also usually designated as kanamycin), and kanamycins B, C, D and X the minor components.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>kanamycin</rdfs:label>
     </owl:Class>
     
@@ -6745,11 +6740,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_61120 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_61120">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33833"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_61120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33833"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
         <obo:IAO_0000115>Any compound that has a nucleobase as a part.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nucleobase-containing molecular entity</rdfs:label>
     </owl:Class>
     
@@ -6757,10 +6752,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_61689 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_61689">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23451"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_61689">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23451"/>
         <obo:IAO_0000115>Any cyclitol having one or more alcoholic hydroxy groups replaced by substituted or unsubstituted amino groups.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>amino cyclitol</rdfs:label>
     </owl:Class>
     
@@ -6768,10 +6763,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_61800 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_61800">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_61689"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_61800">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_61689"/>
         <obo:IAO_0000115>Any derivative of 2-deoxystreptamine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>2-deoxystreptamine derivative</rdfs:label>
     </owl:Class>
     
@@ -6779,11 +6774,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_62732 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_62732">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35701"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_62732">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
         <obo:IAO_0000115>An ester where the ester linkage is bonded directly to an aromatic system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aromatic ester</rdfs:label>
     </owl:Class>
     
@@ -6791,11 +6786,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_62733 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_62733">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32988"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33659"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_62733">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32988"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33659"/>
         <obo:IAO_0000115>An amide in which the amide linkage is bonded directly to an aromatic system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>aromatic amide</rdfs:label>
     </owl:Class>
     
@@ -6803,10 +6798,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_62764 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_62764">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51143"/>
-        <obo:IAO_0000115>A family of nitrogen molecular entities which are highly reactive and derived from nitric oxide (.NO) and superoxide (O2.(-)) produced via the enzymatic activity of inducible nitric oxide synthase 2 (NOS2) and NADPH oxidase respectively.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_62764">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51143"/>
+        <obo:IAO_0000115>A family of nitrogen molecular entities which are highly reactive and derived from nitric oxide (•NO) and superoxide (O&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;•&lt;small&gt;&lt;sup&gt;−&lt;/small&gt;&lt;/sup&gt;) produced via the enzymatic activity of inducible nitric oxide synthase 2 (NOS2) and NADPH oxidase respectively.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>reactive nitrogen species</rdfs:label>
     </owl:Class>
     
@@ -6814,10 +6809,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63161 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63161">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative arising formally from the elimination of water from a glycosidic hydroxy group and an H atom bound to an oxygen, carbon, nitrogen or sulfur atom of a separate entity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>glycosyl compound</rdfs:label>
     </owl:Class>
     
@@ -6825,10 +6820,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63276 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63276">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <obo:IAO_0000115>Name for a family of macrolide antibiotics with more than twenty members produced by the rare actinomycete Micromonospora griseorubida.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63276">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <obo:IAO_0000115>Name for a family of macrolide antibiotics with more than twenty members produced by the rare actinomycete &lt;em&gt;Micromonospora griseorubida&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mycinamicin</rdfs:label>
     </owl:Class>
     
@@ -6836,10 +6831,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63284 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63284">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63276"/>
-        <obo:IAO_0000115>A mycinamicin composed of a 16-membered ring macrolactone core, an N,N-dimethylated deoxysugar desosamine and a 2,3-di-O-methylated 6-deoxysugar mycinose.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63284">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63276"/>
+        <obo:IAO_0000115>A mycinamicin composed of a 16-membered ring macrolactone core, an &lt;em&gt;N&lt;/em&gt;,&lt;em&gt;N&lt;/em&gt;-dimethylated deoxysugar desosamine and a 2,3-di-&lt;em&gt;O&lt;/em&gt;-methylated 6-deoxysugar mycinose.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mycinamicin IV</rdfs:label>
     </owl:Class>
     
@@ -6847,10 +6842,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63299 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63299">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_78616"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63299">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_78616"/>
         <obo:IAO_0000115>Any organooxygen compound derived from a carbohydrate by replacement of one or more hydroxy group(s) by an amino group, a thiol group or similar heteroatomic groups. The term also includes derivatives of these compounds.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbohydrate derivative</rdfs:label>
     </owl:Class>
     
@@ -6858,10 +6853,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63353 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63353">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63353">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative that is formally obtained from a disaccharide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>disaccharide derivative</rdfs:label>
     </owl:Class>
     
@@ -6869,10 +6864,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63367 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63367">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative that is formally obtained from a monosaccharide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monosaccharide derivative</rdfs:label>
     </owl:Class>
     
@@ -6880,11 +6875,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63563 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63563">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_167559"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63563">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_167559"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative that is formally obtained from an oligosaccharide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oligosaccharide derivative</rdfs:label>
     </owl:Class>
     
@@ -6892,10 +6887,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63567 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63567">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63563"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63567">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63563"/>
         <obo:IAO_0000115>An oligosaccharide derivative that is formally obtained from a tetrasaccharide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>tetrasaccharide derivative</rdfs:label>
     </owl:Class>
     
@@ -6903,12 +6898,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63598 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63598">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_194135"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
-        <obo:IAO_0000115>An optically active form of ofloxacin having (S)-configuration; an inhibitor of bacterial topoisomerase IV and DNA gyrase.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63598">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_194135"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
+        <obo:IAO_0000115>An optically active form of ofloxacin having (&lt;i&gt;S&lt;/i&gt;)-configuration; an inhibitor of bacterial topoisomerase IV and DNA gyrase.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:6440</oboInOwl:hasAlternativeId>
         <rdfs:label>levofloxacin</rdfs:label>
     </owl:Class>
@@ -6917,13 +6912,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63607 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63607">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22160"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37143"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38785"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55374"/>
-        <obo:IAO_0000115>An organofluorine compound that consists of 1,3-oxazolidin-2-one bearing an N-3-fluoro-4-(morpholin-4-yl)phenyl group as well as an acetamidomethyl group at position 5. A synthetic antibacterial agent that inhibits bacterial protein synthesis by binding to a site on 23S ribosomal RNA of the 50S subunit and prevents further formation of a functional 70S initiation complex.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63607">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22160"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37143"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38785"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55374"/>
+        <obo:IAO_0000115>An organofluorine compound that consists of 1,3-oxazolidin-2-one bearing an &lt;em&gt;N&lt;/em&gt;-3-fluoro-4-(morpholin-4-yl)phenyl group as well as an acetamidomethyl group at position 5. A synthetic antibacterial agent that inhibits bacterial protein synthesis by binding to a site on 23S ribosomal RNA of the 50S subunit and prevents further formation of a functional 70S initiation complex.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:6477</oboInOwl:hasAlternativeId>
         <rdfs:label>linezolid</rdfs:label>
     </owl:Class>
@@ -6932,16 +6927,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63611 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63611">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35618"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51454"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63697"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
-        <obo:IAO_0000115>A quinolone that consists of 4-oxo-1,4-dihydroquinoline-3-carboxylic acid bearing a cyclopropyl substituent at position 1, a fluoro substitiuent at position 6, a (4aS,7aS)-octahydro-6H-pyrrolo[3,4-b]pyridin-6-yl group at position 7 and a methoxy substituent at position 8. A member of the fluoroquinolone class of antibacterial agents.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63611">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51454"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63697"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
+        <obo:IAO_0000115>A quinolone that consists of 4-oxo-1,4-dihydroquinoline-3-carboxylic acid bearing a cyclopropyl substituent at position 1, a fluoro substitiuent at position 6, a (4a&lt;i&gt;S&lt;/i&gt;,7a&lt;i&gt;S&lt;/i&gt;)-octahydro-6&lt;em&gt;H&lt;/em&gt;-pyrrolo[3,4-&lt;em&gt;b&lt;/em&gt;]pyridin-6-yl group at position 7 and a methoxy substituent at position 8. A member of the fluoroquinolone class of antibacterial agents.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:7007</oboInOwl:hasAlternativeId>
         <rdfs:label>moxifloxacin</rdfs:label>
     </owl:Class>
@@ -6950,10 +6945,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63627 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63627">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24780"/>
-        <obo:IAO_0000115>1H-imidazole substituted at C-1 by a (2-ethylsulfonyl)ethyl group, at C-2 by a methyl group and at C-5 by a nitro group.  It is used as an antiprotozoal, antibacterial agent.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63627">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24780"/>
+        <obo:IAO_0000115>1&lt;em&gt;H&lt;/em&gt;-imidazole substituted at C-1 by a (2-ethylsulfonyl)ethyl group, at C-2 by a methyl group and at C-5 by a nitro group.  It is used as an antiprotozoal, antibacterial agent.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:32227</oboInOwl:hasAlternativeId>
         <rdfs:label>tinidazole</rdfs:label>
     </owl:Class>
@@ -6962,11 +6957,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63697 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63697">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <obo:IAO_0000115>Any organic heterobicyclic compound containing ortho-fused pyrrolidine and piperidine rings.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63697">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <obo:IAO_0000115>Any organic heterobicyclic compound containing &lt;em&gt;ortho&lt;/em&gt;-fused pyrrolidine and piperidine rings.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pyrrolidinopiperidine</rdfs:label>
     </owl:Class>
     
@@ -6974,11 +6969,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63845 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63845">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_48975"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_90852"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63845">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_48975"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_90852"/>
         <obo:IAO_0000115>A sulfonamide that is sulfanilamide acylated on the sulfonamide nitrogen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfacetamide</rdfs:label>
     </owl:Class>
     
@@ -6986,11 +6981,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_63944 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_63944">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25000"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51026"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_63944">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
         <obo:IAO_0000115>Any lactone in which the cyclic carboxylic ester group forms a part of a cyclic macromolecule.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:50333</oboInOwl:hasAlternativeId>
         <rdfs:label>macrocyclic lactone</rdfs:label>
     </owl:Class>
@@ -6999,10 +6994,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_64509 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_64509">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35627"/>
-        <obo:IAO_0000115>A fused-ring beta-lactam system where the beta-lactam ring is fused to a 1,3-oxazolidine ring.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_64509">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35627"/>
+        <obo:IAO_0000115>A fused-ring β-lactam system where the β-lactam ring is fused to a 1,3-oxazolidine ring.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>oxapenam</rdfs:label>
     </owl:Class>
     
@@ -7010,10 +7005,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_64709 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_64709">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_64709">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>Any organic molecular entity that is acidic and contains carbon in covalent linkage.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic acid</rdfs:label>
     </owl:Class>
     
@@ -7021,13 +7016,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6472 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6472">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23007"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35275"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46770"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_84186"/>
-        <obo:IAO_0000115>A carbohydrate-containing antibiotic produced by the actinomyces Streptomyces lincolnensis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6472">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23007"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_29347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35275"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_84186"/>
+        <obo:IAO_0000115>A carbohydrate-containing antibiotic produced by the actinomyces &lt;em&gt;Streptomyces lincolnensis&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lincomycin</rdfs:label>
     </owl:Class>
     
@@ -7035,12 +7031,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_65212 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_65212">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_167559"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33694"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_65212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_167559"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33694"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative that is any derivative of a polysaccharide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polysaccharide derivative</rdfs:label>
     </owl:Class>
     
@@ -7048,9 +7044,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6633 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6633">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33860"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6633">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33860"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Mafenide</rdfs:label>
     </owl:Class>
     
@@ -7058,10 +7054,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6827 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6827">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6827">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin that is 6-aminopenicillanic acid in which one of the amino hydrogens is replaced by a 2,6-dimethoxybenzoyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>methicillin</rdfs:label>
     </owl:Class>
     
@@ -7069,11 +7066,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_68452 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_68452">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38179"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_68452">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38179"/>
         <obo:IAO_0000115>Any monocyclic heteroarene consisting of a five-membered ring containing nitrogen. Azoles can also contain one or more other non-carbon atoms, such as nitrogen, sulfur or oxygen.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>azole</rdfs:label>
     </owl:Class>
     
@@ -7081,13 +7078,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_68590 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_68590">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24400"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33853"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36683"/>
-        <obo:IAO_0000115>An 18-membered macrolide that is a fermentation product obtained from the Actinomycete Dactylosporangium aurantiacum. A narrow spectrum antibiotic used for treatment of Clostridium difficile-related infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_68590">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24400"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33853"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36683"/>
+        <obo:IAO_0000115>An 18-membered macrolide that is a fermentation product obtained from the Actinomycete &lt;em&gt;Dactylosporangium aurantiacum&lt;/em&gt;. A narrow spectrum antibiotic used for treatment of &lt;em&gt;Clostridium difficile&lt;/em&gt;-related infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>fidaxomicin</rdfs:label>
     </owl:Class>
     
@@ -7095,12 +7093,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6909 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6909">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_15734"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24780"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35716"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6909">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15734"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24780"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35716"/>
         <obo:IAO_0000115>A member of the class of imidazoles substituted at C-1, -2 and -5 with 2-hydroxyethyl, nitro and methyl groups respectively. It has activity against anaerobic bacteria and protozoa, and has a radiosensitising effect on hypoxic tumour cells. It may be given by mouth in tablets, or as the benzoate in an oral suspension. The hydrochloride salt can be used in intravenous infusions. Metronidazole is a prodrug and is selective for anaerobic bacteria due to their ability to intracellularly reduce the nitro group of metronidazole to give nitroso-containing intermediates. These can covalently bind to DNA, disrupting its helical structure, inducing DNA strand breaks and inhibiting bacterial nucleic acid synthesis, ultimately resulting in bacterial cell death.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:39845</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:63636</oboInOwl:hasAlternativeId>
         <rdfs:label>metronidazole</rdfs:label>
@@ -7110,10 +7108,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_6919 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_6919">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
-        <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a (2R)-2-[3-(methanesulfonyl)-2-oxoimidazolidine-1-carboxamido]-2-phenylacetamido group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_6919">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
+        <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a (2&lt;i&gt;R&lt;/i&gt;)-2-[3-(methanesulfonyl)-2-oxoimidazolidine-1-carboxamido]-2-phenylacetamido group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>mezlocillin</rdfs:label>
     </owl:Class>
     
@@ -7121,15 +7120,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_7025 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_7025">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27136"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_32955"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35681"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46942"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51737"/>
-        <obo:IAO_0000115>An alpha,beta-unsaturated ester resulting from the formal condensation of the alcoholic hydroxy group of 9-hydroxynonanoic acid with the carboxy group of (2E)-4-[(2S)-tetrahydro-2H-pyran-2-yl]-3-methylbut-2-enoic acid in which the tetrahydropyranyl ring is substituted at positions 3 and 4 by hydroxy groups and at position 5 by a {(2S,3S)-3-[(2S,3S)-3-hydroxybutan-2-yl]oxiran-2-yl}methyl group. Originally isolated from the Gram-negative bacterium Pseudomonas fluorescens, it is used as a topical antibiotic for the treatment of Gram-positive bacterial infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_7025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27136"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32955"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46942"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51737"/>
+        <obo:IAO_0000115>An α,β-unsaturated ester resulting from the formal condensation of the alcoholic hydroxy group of 9-hydroxynonanoic acid with the carboxy group of (2&lt;i&gt;E&lt;/i&gt;)-4-[(2&lt;i&gt;S&lt;/i&gt;)-tetrahydro-2&lt;em&gt;H&lt;/em&gt;-pyran-2-yl]-3-methylbut-2-enoic acid in which the tetrahydropyranyl ring is substituted at positions 3 and 4 by hydroxy groups and at position 5 by a {(2&lt;i&gt;S&lt;/i&gt;,3&lt;i&gt;S&lt;/i&gt;)-3-[(2&lt;i&gt;S&lt;/i&gt;,3&lt;i&gt;S&lt;/i&gt;)-3-hydroxybutan-2-yl]oxiran-2-yl}methyl group. Originally isolated from the Gram-negative bacterium &lt;em&gt;Pseudomonas fluorescens&lt;/em&gt;, it is used as a topical antibiotic for the treatment of Gram-positive bacterial infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:44038</oboInOwl:hasAlternativeId>
         <rdfs:label>mupirocin</rdfs:label>
     </owl:Class>
@@ -7138,15 +7137,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_70718 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_70718">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23066"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35285"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36816"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37773"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38099"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38418"/>
-        <obo:IAO_0000115>A cephalosporin having [4-(1-methylpyridinium-4-yl)-1,3-thiazol-2-yl]sulfanyl and {(2Z)-2-(ethoxyimino)-2-[5-(phosphonoamino)-1,2,4-thiadiazol-3-yl]acetyl}amino side groups located at positions 3 and 7 respectively. The N-phospho prodrug of ceftaroline, a broad-spectrum antibiotic active against methicillin-resistant Staphylococcus aureus (MRSA). It is used for the treatment of adults with acute bacterial skin and skin structure infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_70718">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23066"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35285"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36816"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37773"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38099"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38418"/>
+        <obo:IAO_0000115>A cephalosporin having [4-(1-methylpyridinium-4-yl)-1,3-thiazol-2-yl]sulfanyl and {(2&lt;i&gt;Z&lt;/i&gt;)-2-(ethoxyimino)-2-[5-(phosphonoamino)-1,2,4-thiadiazol-3-yl]acetyl}amino side groups located at positions 3 and 7 respectively. The &lt;em&gt;N&lt;/em&gt;-phospho prodrug of ceftaroline, a broad-spectrum antibiotic active against methicillin-resistant &lt;em&gt;Staphylococcus aureus&lt;/em&gt; (MRSA). It is used for the treatment of adults with acute bacterial skin and skin structure infections.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ceftaroline fosamil</rdfs:label>
     </owl:Class>
     
@@ -7154,10 +7153,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_71229 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_71229">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_71229">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
         <obo:IAO_0000115>A glycopeptide that is vancomycin substituted at position N-3&apos;&apos; by a 2-(decylamino)ethyl group and at position C-29 by a (phosphonomethyl)aminomethyl group. Used as its hydrochloride salt for treatment of adults with complicated skin and skin structure infections caused by bacteria.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>telavancin</rdfs:label>
     </owl:Class>
     
@@ -7165,11 +7164,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_71415 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_71415">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24628"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87230"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_71415">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24628"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25807"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87230"/>
         <obo:IAO_0000115>An imidazolidine-2,4-dione that is hydantoin substituted at position 1 by a [(5-nitro-2-furyl)methylene]amino group. An antibiotic that damages bacterial DNA.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:7591</oboInOwl:hasAlternativeId>
         <rdfs:label>nitrofurantoin</rdfs:label>
     </owl:Class>
@@ -7178,11 +7179,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_71960 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_71960">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <obo:IAO_0000115>Any member of a family of aminoglycosidic antibiotics produced by the bacterium Streptomyces lividus. Note that one member of this class, lividomycin A, is also known as lividomycin.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_71960">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <obo:IAO_0000115>Any member of a family of aminoglycosidic antibiotics produced by the bacterium &lt;em&gt;Streptomyces lividus&lt;/em&gt;. Note that one member of this class, lividomycin A, is also known as lividomycin.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lividomycins</rdfs:label>
     </owl:Class>
     
@@ -7190,10 +7191,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_71961 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_71961">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_71960"/>
-        <obo:IAO_0000115>A member of the class of lividomycins that is lividomycin B in which position 4 of the diamino-L-idopyranosyl moiety has been converted into its alpha-D-mannopyranoside.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_71961">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_71960"/>
+        <obo:IAO_0000115>A member of the class of lividomycins that is lividomycin B in which position 4 of the diamino-&lt;small&gt;L&lt;/small&gt;-idopyranosyl moiety has been converted into its α-&lt;small&gt;D&lt;/small&gt;-mannopyranoside.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lividomycin A</rdfs:label>
     </owl:Class>
     
@@ -7201,10 +7202,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_71962 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_71962">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_71960"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_71962">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_71960"/>
         <obo:IAO_0000115>A member of the class of lividomycins that is paromomycin in which the 2-amino-2-deoxyglucopyranosyl moiety is lacking the hydroxy group at position 3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>lividomycin B</rdfs:label>
     </owl:Class>
     
@@ -7212,15 +7213,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_72292 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_72292">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25477"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26513"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26878"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35618"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37141"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_72292">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25477"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26513"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26878"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37141"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
         <obo:IAO_0000115>A quinoline-based antimycobacterial drug used (as its fumarate salt) for the treatment of pulmonary multi-drug resistant tuberculosis by inhibition of ATP synthase, an enzyme essential for the replication of the mycobacteria.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>bedaquiline</rdfs:label>
     </owl:Class>
     
@@ -7228,10 +7229,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_72588 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_72588">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_72588">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>Any organic molecular entity derived from a natural product by partial chemical synthesis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>semisynthetic derivative</rdfs:label>
     </owl:Class>
     
@@ -7239,11 +7240,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_72695 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_72695">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25367"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_72695">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25367"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>Any molecule that consists of at least one carbon atom as part of the electrically neutral entity.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>organic molecule</rdfs:label>
     </owl:Class>
     
@@ -7251,10 +7252,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_73537 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_73537">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_73539"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_73537">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_73539"/>
         <obo:IAO_0000115>Any naphthyridine derivative that is a derivative of 1,8-naphthyridine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>1,8-naphthyridine derivative</rdfs:label>
     </owl:Class>
     
@@ -7262,11 +7263,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_73539 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_73539">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27171"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38101"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_73539">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
         <obo:IAO_0000115>Any organonitrogen heterocyclic compound that is a derivative of a naphthyridine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>naphthyridine derivative</rdfs:label>
     </owl:Class>
     
@@ -7274,11 +7275,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_73754 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_73754">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33261"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63299"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_73754">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33261"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63299"/>
         <obo:IAO_0000115>A carbohydrate derivative in which one or more of the oxygens or hydroxy groups of the parent carbohydrate is replaced by sulfur or -SR, where R can be hydrogen or any group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>thiosugar</rdfs:label>
     </owl:Class>
     
@@ -7286,10 +7287,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_73772 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_73772">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_65212"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_73772">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_65212"/>
         <obo:IAO_0000115>Any capsular polysaccharide derivative which is carried on the surface of a bacterial capsule or formed on the outer portion of a cell wall and masks somatic O antigens.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>K antigen</rdfs:label>
     </owl:Class>
     
@@ -7297,10 +7298,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_74159 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_74159">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27369"/>
-        <obo:IAO_0000115>A zwitterion resulting from the transfer of a proton from the ring nitrogen to the primary amino group of D-cycloserine. The major species at pH 7.3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_74159">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27369"/>
+        <obo:IAO_0000115>A zwitterion resulting from the transfer of a proton from the ring nitrogen to the primary amino group of &lt;small&gt;D&lt;/small&gt;-cycloserine. The major species at pH 7.3.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>D-cycloserine zwitterion</rdfs:label>
     </owl:Class>
     
@@ -7308,10 +7309,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_7447 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_7447">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_7447">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a (2-ethoxy-1-naphthoyl)amino group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:44256</oboInOwl:hasAlternativeId>
         <rdfs:label>nafcillin</rdfs:label>
     </owl:Class>
@@ -7320,10 +7322,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_7508 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_7508">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47779"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_7508">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47779"/>
         <obo:IAO_0000115>A tetracyclic antibacterial agent derived from neomycin, being a glycoside ester of neamine and neobiosamine B.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:44577</oboInOwl:hasAlternativeId>
         <rdfs:label>framycetin</rdfs:label>
     </owl:Class>
@@ -7332,14 +7334,16 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_75246 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_75246">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26580"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_47622"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51914"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59779"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_75246">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26580"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_47622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51914"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59779"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
         <obo:IAO_0000115>A semisynthetic member of the class of rifamycins and non-systemic gastrointestinal site-specific broad spectrum antibiotic. Used in the treatment of traveller&apos;s diarrhoea, hepatic encephalopathy and irritable bowel syndrome.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>rifaximin</rdfs:label>
     </owl:Class>
     
@@ -7347,10 +7351,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_75606 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_75606">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_75606">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
         <obo:IAO_0000115>A carboxamide that is a hydroxamic acid in which the hydrogen of the hydroxy group is replaced by an organyl group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>hydroxamic acid ester</rdfs:label>
     </owl:Class>
     
@@ -7358,11 +7362,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_75769 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_75769">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>Any member of the group of eight water-soluble vitamins originally thought to be a single compound (vitamin B) that play important roles in cell metabolism. The group comprises of vitamin B1, B2, B3, B5, B6, B7, B9, and B12 (Around 20 other compounds were once thought to be B vitamins but are no longer classified as such).</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_75769">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>Any member of the group of eight water-soluble vitamins originally thought to be a single compound (vitamin B) that play important roles in cell metabolism. The group comprises of vitamin B&lt;small&gt;&lt;sub&gt;1&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;3&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;5&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;6&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;7&lt;/sub&gt;&lt;/small&gt;, B&lt;small&gt;&lt;sub&gt;9&lt;/sub&gt;&lt;/small&gt;, and B&lt;small&gt;&lt;sub&gt;12&lt;/sub&gt;&lt;/small&gt; (Around 20 other compounds were once thought to be B vitamins but are no longer classified as such).</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>B vitamin</rdfs:label>
     </owl:Class>
     
@@ -7370,10 +7374,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_76892 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_76892">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25696"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_76892">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25696"/>
         <obo:IAO_0000115>An organic anion obtained by deprotonation of the carboxy, sulfo and one of the hydroxy groups as well as protonation of the amino group of A47934; major species at pH 7.3.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>A47934(2-)</rdfs:label>
     </owl:Class>
     
@@ -7381,12 +7385,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_7731 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_7731">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_60911"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_7731">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_60911"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
         <obo:IAO_0000115>A racemate comprising equimolar amounts of levofloxacin and dextrofloxacin. It is a synthetic fluoroquinolone antibacterial agent which inhibits the supercoiling activity of bacterial DNA gyrase, halting DNA replication.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:100146</oboInOwl:hasAlternativeId>
         <rdfs:label>ofloxacin</rdfs:label>
     </owl:Class>
@@ -7395,10 +7399,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_78616 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_78616">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36963"/>
-        <obo:IAO_0000115>Any organooxygen compound that is a polyhydroxy-aldehyde or -ketone, or a compound derived from one. Carbohydrates contain only carbon, hydrogen and oxygen and usually have an empirical formula Cm(H2O)n; carbohydrate derivatives may contain other elements by substitution or condensation.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_78616">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+        <obo:IAO_0000115>Any organooxygen compound that is a polyhydroxy-aldehyde or -ketone, or a compound derived from one. Carbohydrates contain only carbon, hydrogen and oxygen and usually have an empirical formula C&lt;small&gt;&lt;sub&gt;&lt;em&gt;m&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;(H&lt;small&gt;&lt;sub&gt;2&lt;/sub&gt;&lt;/small&gt;O)&lt;small&gt;&lt;sub&gt;&lt;em&gt;n&lt;/em&gt;&lt;/sub&gt;&lt;/small&gt;; carbohydrate derivatives may contain other elements by substitution or condensation.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>carbohydrates and carbohydrate derivatives</rdfs:label>
     </owl:Class>
     
@@ -7406,10 +7410,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_78840 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_78840">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_78840">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
         <obo:IAO_0000115>Any organic molecular entity that contains at least one C=C bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>olefinic compound</rdfs:label>
     </owl:Class>
     
@@ -7417,10 +7421,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_79020 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_79020">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25384"/>
-        <obo:IAO_0000115>A monocarboxylic acid in which the carbon of the carboxy group is directly attached to a C=C or C#C bond.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_79020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25384"/>
+        <obo:IAO_0000115>A monocarboxylic acid in which the carbon of the carboxy group is directly attached to a C=C or C≡C bond.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>alpha,beta-unsaturated monocarboxylic acid</rdfs:label>
     </owl:Class>
     
@@ -7428,11 +7432,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_7934 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_7934">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22479"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_22507"/>
-        <obo:IAO_0000115>An amino cyclitol glycoside that is the 1-O-(2-amino-2-deoxy-alpha-D-glucopyranoside) and the 3-O-(2,6-diamino-2,6-dideoxy-beta-L-idopyranosyl)-beta-D-ribofuranoside of 4,6-diamino-2,3-dihydroxycyclohexane (the 1R,2R,3S,4R,6S diastereoisomer). It is obtained from various Streptomyces species. A broad-spectrum antibiotic, it is used (generally as the sulfate salt) for the treatment of acute and chronic intestinal protozoal infections, but is not effective for extraintestinal protozoal infections. It is also used as a therapeutic against visceral leishmaniasis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_7934">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22479"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22507"/>
+        <obo:IAO_0000115>An amino cyclitol glycoside that is the 1-&lt;em&gt;O&lt;/em&gt;-(2-amino-2-deoxy-α-&lt;small&gt;D&lt;/small&gt;-glucopyranoside) and the 3-&lt;em&gt;O&lt;/em&gt;-(2,6-diamino-2,6-dideoxy-β-&lt;small&gt;L&lt;/small&gt;-idopyranosyl)-β-&lt;small&gt;D&lt;/small&gt;-ribofuranoside of 4,6-diamino-2,3-dihydroxycyclohexane (the 1&lt;i&gt;R&lt;/i&gt;,2&lt;i&gt;R&lt;/i&gt;,3&lt;i&gt;S&lt;/i&gt;,4&lt;i&gt;R&lt;/i&gt;,6&lt;i&gt;S&lt;/i&gt; diastereoisomer). It is obtained from various &lt;em&gt;Streptomyces&lt;/em&gt; species. A broad-spectrum antibiotic, it is used (generally as the sulfate salt) for the treatment of acute and chronic intestinal protozoal infections, but is not effective for extraintestinal protozoal infections. It is also used as a therapeutic against visceral leishmaniasis.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:44703</oboInOwl:hasAlternativeId>
         <rdfs:label>paromomycin</rdfs:label>
     </owl:Class>
@@ -7441,10 +7445,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_79389 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_79389">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24834"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_79389">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24834"/>
         <obo:IAO_0000115>Any inorganic anion with a valency of one.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monovalent inorganic anion</rdfs:label>
     </owl:Class>
     
@@ -7452,9 +7456,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_80016 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_80016">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_80016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Chalcomycin</rdfs:label>
     </owl:Class>
     
@@ -7462,10 +7466,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8232 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8232">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
         <obo:IAO_0000115>A penicillin in which the substituent at position 6 of the penam ring is a 2-[(4-ethyl-2,3-dioxopiperazin-1-yl)carboxamido]-2-phenylacetamido group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:472443</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:475140</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:505944</oboInOwl:hasAlternativeId>
@@ -7476,11 +7481,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8269 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8269">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33308"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38032"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_3992"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8269">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38032"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_3992"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Pleuromutilin</rdfs:label>
     </owl:Class>
     
@@ -7488,12 +7493,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_82699 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_82699">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63353"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_72588"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_82699">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63353"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_72588"/>
         <obo:IAO_0000115>A semisynthetic glycopeptide used (as its bisphosphate salt) for the treatment of acute bacterial skin and skin structure infections caused or suspected to be caused by susceptible isolates of designated Gram-positive microorganisms including MRSA.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:29553</oboInOwl:hasAlternativeId>
         <rdfs:label>oritavancin</rdfs:label>
     </owl:Class>
@@ -7502,10 +7507,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8309 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8309">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59062"/>
-        <obo:IAO_0000115>A polymyxin having a (6R)-6-methyloctanoyl group at the amino terminus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59062"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>polymyxin B1</rdfs:label>
     </owl:Class>
     
@@ -7513,10 +7517,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_83403 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_83403">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23132"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_83403">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23132"/>
         <obo:IAO_0000115>Any member of the class of chlorobenzenes containing a mono- or poly-substituted benzene ring in which only one substituent is chlorine.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>monochlorobenzenes</rdfs:label>
     </owl:Class>
     
@@ -7524,10 +7528,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_83628 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_83628">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37622"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_83628">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37622"/>
         <obo:IAO_0000115>A carboxamide obtained by the formal condensation of the carboxy group of any carboxylic acid with ammonia.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-acylammonia</rdfs:label>
     </owl:Class>
     
@@ -7535,10 +7539,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_83811 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_83811">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83821"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_83811">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83821"/>
         <obo:IAO_0000115>Any derivative of a proteinogenic amino acid resulting from reaction at an amino group, carboxy group, or a side-chain functional group, or from the replacement of any hydrogen by a heteroatom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>proteinogenic amino acid derivative</rdfs:label>
     </owl:Class>
     
@@ -7546,21 +7550,21 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_83821 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_83821">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35352"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_83821">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
         <obo:IAO_0000115>Any derivative of an amino acid resulting from reaction at an amino group, carboxy group, side-chain functional group, or from the replacement of any hydrogen by a heteroatom. The definition normally excludes peptides containing amino acid residues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:25359</oboInOwl:hasAlternativeId>
-        <rdfs:label>amino acid derivative</rdfs:label>
+        <rdfs:label>amino-acid derivative</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8418 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8418">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35213"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Pristinamycin IB</rdfs:label>
     </owl:Class>
     
@@ -7568,11 +7572,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_84186 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_84186">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26273"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_83811"/>
-        <obo:IAO_0000115>A proteinogenic amino acid derivative resulting from reaction of L-proline at the amino group or the carboxy group, or from the replacement of any hydrogen of L-proline  by a heteroatom.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_84186">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26273"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_83811"/>
+        <obo:IAO_0000115>A proteinogenic amino acid derivative resulting from reaction of &lt;small&gt;L&lt;/small&gt;-proline at the amino group or the carboxy group, or from the replacement of any hydrogen of &lt;small&gt;L&lt;/small&gt;-proline  by a heteroatom.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>L-proline derivative</rdfs:label>
     </owl:Class>
     
@@ -7580,9 +7584,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8419 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8419">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35213"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8419">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>pristinamycin IC</rdfs:label>
     </owl:Class>
     
@@ -7590,13 +7594,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_85129 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_85129">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24396"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24533"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51026"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63567"/>
-        <obo:IAO_0000115>A heterodetic cyclic peptide  that is produced by species of Amycolatopsis and Nocardia.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_85129">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24533"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51026"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63567"/>
+        <obo:IAO_0000115>A heterodetic cyclic peptide  that is produced by species of &lt;em&gt;Amycolatopsis&lt;/em&gt; and &lt;em&gt;Nocardia&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ristocetin</rdfs:label>
     </owl:Class>
     
@@ -7604,14 +7608,14 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_85260 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_85260">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17478"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25106"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25698"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50996"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_63353"/>
-        <obo:IAO_0000115>A macrolide antibiotic produced by various Streptomyces species that is used to treat toxoplasmosis and various other infections of soft tissues.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_85260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25698"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50996"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_63353"/>
+        <obo:IAO_0000115>A macrolide antibiotic produced by various &lt;em&gt;Streptomyces&lt;/em&gt; species that is used to treat toxoplasmosis and various other infections of soft tissues.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:45589</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>CHEBI:9236</oboInOwl:hasAlternativeId>
         <rdfs:label>spiramycin I</rdfs:label>
@@ -7621,10 +7625,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_86324 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_86324">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25558"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_86324">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
         <obo:IAO_0000115>An organonitrogen heterocyclic antibiotic whose structure contains a quinolone or quinolone-related skeleton.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>quinolone antibiotic</rdfs:label>
     </owl:Class>
     
@@ -7632,10 +7636,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_86478 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_86478">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33285"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_86478">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33285"/>
         <obo:IAO_0000115>Heteroorganic entities that are microbial metabolites (or compounds derived from them) which have significant antifungal properties.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>antibiotic antifungal agent</rdfs:label>
     </owl:Class>
     
@@ -7643,10 +7647,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_87113 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_87113">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86478"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_87113">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86478"/>
         <obo:IAO_0000115>Any antibiotic antifungal agent used to treat fungal infections in humans or animals.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>antibiotic antifungal drug</rdfs:label>
     </owl:Class>
     
@@ -7654,10 +7658,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_87114 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_87114">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86478"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_87114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86478"/>
         <obo:IAO_0000115>Any antibiotic antifungal agent that has been used as a fungicide.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>antibiotic fungicide</rdfs:label>
     </owl:Class>
     
@@ -7665,11 +7669,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_87211 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_87211">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25558"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37143"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_87211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37143"/>
         <obo:IAO_0000115>An organonitrogen heterocyclic antibiotic containing a quinolone (or quinolone-like) moiety and which have a fluorine atom attached to the central ring system.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>fluoroquinolone antibiotic</rdfs:label>
     </owl:Class>
     
@@ -7677,10 +7681,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_87228 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_87228">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35358"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_87228">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
         <obo:IAO_0000115>A class of sulfonamides whose members generally have bacteriostatic antibiotic properties.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfonamide antibiotic</rdfs:label>
     </owl:Class>
     
@@ -7688,13 +7692,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_87230 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_87230">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24129"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25558"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25807"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35716"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_87230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24129"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25558"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25807"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35716"/>
         <obo:IAO_0000115>A member of the class of furans in which the furan ring is substituted by a nitro group and which also has significant antibiotic properties.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nitrofuran antibiotic</rdfs:label>
     </owl:Class>
     
@@ -7702,9 +7706,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8732 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8732">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35213"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8732">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Quinupristin</rdfs:label>
     </owl:Class>
     
@@ -7712,9 +7716,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_8733 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_8733">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50860"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_8733">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>Quinupristin-dalfopristin</rdfs:label>
     </owl:Class>
     
@@ -7722,10 +7726,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_88187 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_88187">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_17334"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_88187">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
         <obo:IAO_0000115>Any penicillin which causes the onset of an allergic reaction.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>penicillin allergen</rdfs:label>
     </owl:Class>
     
@@ -7733,10 +7737,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_88225 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_88225">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_27933"/>
-        <obo:IAO_0000115>Any beta-lactam antibiotic which causes the onset of an allergic reaction.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_88225">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27933"/>
+        <obo:IAO_0000115>Any β-lactam antibiotic which causes the onset of an allergic reaction.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>beta-lactam antibiotic allergen</rdfs:label>
     </owl:Class>
     
@@ -7744,11 +7748,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9016 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9016">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_33406"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_36807"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50954"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33406"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36807"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50954"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>arsphenamine</rdfs:label>
     </owl:Class>
     
@@ -7756,10 +7760,10 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_90852 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_90852">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_37716"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_90852">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37716"/>
         <obo:IAO_0000115>A mixed diacylamine resulting from the formal condensation of the nitrogen of a carboxamide with a sulphonic acid.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>N-sulfonylcarboxamide</rdfs:label>
     </owl:Class>
     
@@ -7767,13 +7771,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9212 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9212">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23765"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_26512"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46848"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_86324"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87211"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23765"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26512"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46848"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_86324"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87211"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sparfloxacin</rdfs:label>
     </owl:Class>
     
@@ -7781,15 +7785,15 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9215 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9215">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_146295"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35681"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_3992"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_50995"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59770"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_59780"/>
-        <obo:IAO_0000115>A pyranobenzodioxin and antibiotic that is active against gram-negative bacteria and used (as its dihydrochloride pentahydrate) to treat gonorrhea. It is produced by the bacterium Streptomyces spectabilis.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_146295"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_3992"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_59780"/>
+        <obo:IAO_0000115>A pyranobenzodioxin and antibiotic that is active against gram-negative bacteria and used (as its dihydrochloride pentahydrate) to treat gonorrhea. It is produced by the bacterium &lt;em&gt;Streptomyces spectabilis&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:45551</oboInOwl:hasAlternativeId>
         <rdfs:label>spectinomycin</rdfs:label>
     </owl:Class>
@@ -7798,9 +7802,9 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9321 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9321">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25865"/>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9321">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25865"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulbactam</rdfs:label>
     </owl:Class>
     
@@ -7808,12 +7812,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9328 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9328">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39447"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_48975"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87228"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9328">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39447"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_48975"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87228"/>
         <obo:IAO_0000115>A sulfonamide consisting of pyrimidine with a 4-aminobenzenesulfonamido group at the 2-position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfadiazine</rdfs:label>
     </owl:Class>
     
@@ -7821,11 +7826,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9329 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9329">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35358"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_39447"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9329">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_39447"/>
         <obo:IAO_0000115>A sulfonamide consisting of pyrimidine having methoxy substituents at the 5- and 6-positions and a 4-aminobenzenesulfonamido group at the 4-position. In combination with the antiprotozoal pyrimethamine (CHEBI:8673) it is used as an antimalarial.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfadoxine</rdfs:label>
     </owl:Class>
     
@@ -7833,11 +7838,12 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9331 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9331">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_38099"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87228"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9331">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38099"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87228"/>
         <obo:IAO_0000115>A sulfonamide consisting of a 1,3,4-thiadiazole nucleus with a methyl substituent at C-5 and a 4-aminobenzenesulfonamido group at C-2.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>sulfamethizole</rdfs:label>
     </owl:Class>
     
@@ -7845,12 +7851,13 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9332 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9332">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_48975"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_55373"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_87228"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9332">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35358"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_48975"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55373"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_87228"/>
         <obo:IAO_0000115>An isoxazole (1,2-oxazole) compound having a methyl substituent at the 5-position and a 4-aminobenzenesulfonamido group at the 3-position.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:102247</oboInOwl:hasAlternativeId>
         <rdfs:label>sulfamethoxazole</rdfs:label>
     </owl:Class>
@@ -7859,11 +7866,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9421 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9421">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25865"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35727"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25865"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35727"/>
         <obo:IAO_0000115>A member of the class of penicillanic acids that is sulbactam in which one of the exocyclic methyl hydrogens is replaced by a 1,2,3-triazol-1-yl group; used (in the form of its sodium salt) in combination with ceftolozane sulfate for treatment of complicated intra-abdominal infections and complicated urinary tract infections.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:45973</oboInOwl:hasAlternativeId>
         <rdfs:label>tazobactam</rdfs:label>
     </owl:Class>
@@ -7872,10 +7879,11 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9587 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9587">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_88187"/>
-        <obo:IAO_0000115>A penicillin compound having a 6beta-[(2R)-2-carboxy-2-thiophen-3-ylacetyl]amino side-group.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9587">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17334"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88187"/>
+        <obo:IAO_0000115>A penicillin compound having a 6β-[(2&lt;i&gt;R&lt;/i&gt;)-2-carboxy-2-thiophen-3-ylacetyl]amino side-group.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>ticarcillin</rdfs:label>
     </owl:Class>
     
@@ -7883,18 +7891,19 @@
 
     <!-- http://purl.obolibrary.org/obo/CHEBI_9997 -->
 
-    <owl:Class rdf:about="&obo;CHEBI_9997">
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_140325"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_140326"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23763"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_24995"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_25105"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_35681"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_3992"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_46812"/>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_51751"/>
-        <obo:IAO_0000115>A macrolide that is (together with pristinamycin IA) a component of pristinamycin, an oral streptogramin antibiotic produced by Streptomyces pristinaespiralis. Pristinamycin exhibits bactericidal activity against Gram positive organisms including methicillin-resistant Staphylococcus aureus.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="&obo;chebi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_9997">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_140325"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_140326"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23763"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24995"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25106"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_3992"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46812"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_51751"/>
+        <obo:IAO_0000115>A macrolide that is (together with pristinamycin IA) a component of pristinamycin, an oral streptogramin antibiotic produced by &lt;em&gt;Streptomyces pristinaespiralis&lt;/em&gt;. Pristinamycin exhibits bactericidal activity against Gram positive organisms including methicillin-resistant &lt;em&gt;Staphylococcus aureus&lt;/em&gt;.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <oboInOwl:hasAlternativeId>CHEBI:46395</oboInOwl:hasAlternativeId>
         <rdfs:label>pristinamycin IIA</rdfs:label>
     </owl:Class>
@@ -7902,5 +7911,5 @@
 
 
 
-<!-- Generated by the OWL API (version 4.5.25) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi -->
 

--- a/src/ontology/imports/chebi_ontofox.txt
+++ b/src/ontology/imports/chebi_ontofox.txt
@@ -371,7 +371,7 @@ http://purl.obolibrary.org/obo/CHEBI_48838 # gypsum
 
 
 [Top level source term URIs and target direct superclass URIs]
-http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
+http://purl.obolibrary.org/obo/CHEBI_24431 # chemical entity
 subClassOf http://purl.obolibrary.org/obo/BFO_0000040 # material entity
 
 http://purl.obolibrary.org/obo/CHEBI_24432 # biological role 


### PR DESCRIPTION
One remaining puzzle about /src/ontology/imports/chebi_import.owl is why it isn't using xml-entity prefixes for "obo:" etc.